### PR TITLE
Round hours to whole number

### DIFF
--- a/src/index.liquid
+++ b/src/index.liquid
@@ -283,7 +283,7 @@ layout: layouts/base.liquid
                                       {% assign childEndDate = child.dateEnd | date: "%s" %}
                                       {% assign duration_seconds = childEndDate | minus: childStartDate %}
                                       {% assign duration_minutes = duration_seconds | divided_by: 60 %}
-                                      {% assign hours = duration_minutes | divided_by: 60 %}
+                                      {% assign hours = duration_minutes | divided_by: 60 | floor %}
                                       {% assign minutes = duration_minutes | modulo: 60 %}
 
                                       {% if parentEndDate == nil or parentStartDate == parentEndDate %}


### PR DESCRIPTION
This pull request rounds the hours to a whole number. This ensures that the hours are displayed accurately without any decimal places.