### PR TITLE
Show badge on free events

### DIFF
--- a/src/_includes/todaySimple.liquid
+++ b/src/_includes/todaySimple.liquid
@@ -318,7 +318,7 @@
             {% if showFreeBadge %}
               <div class="event__badges">
                 {% if showFreeBadge %}
-                  <sl-badge variant="neutral" pill itemprop="isAccessibleForFree" content="true">Free Event</sl-badge>
+                  <sl-badge variant="neutral" pill itemprop="isAccessibleForFree" content="true">Free of charge</sl-badge>
                 {% endif %}
               </div>
             {% endif %}

--- a/src/_includes/todaySimple.liquid
+++ b/src/_includes/todaySimple.liquid
@@ -312,6 +312,16 @@
                 </details>
               {% endif %}
             <!-- End .event__children -->
+            {% assign currentDate = 'now' | date: '%Y-%m-%dT%H:%M:%S%z' %}
+            {% assign showFreeBadge = event.isFree %}
+            
+            {% if showFreeBadge %}
+              <div class="event__badges">
+                {% if showFreeBadge %}
+                  <sl-badge variant="neutral" pill itemprop="isAccessibleForFree" content="true">Free Event</sl-badge>
+                {% endif %}
+              </div>
+            {% endif %}
             </article>
             <!-- End .event -->
             </li>

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -120,6 +120,7 @@ layout: layouts/base.liquid
                   itemtype="https://schema.org/Event"
                   data-event-type="normal"
                   data-event-attendancemode="{{ event.attendanceMode }}"
+                  {% if event.isFree %}data-event-isfree="{{ event.isFree }}"{% endif %}
                   {% if event.callForSpeakers %}
                     {% if event.callForSpeakersClosingDate == empty %}
                       data-event-cfs
@@ -372,7 +373,7 @@ layout: layouts/base.liquid
                   {% if showCallForSpeakersBadge or showFreeBadge %}
                     <div class="event__badges">
                       {% if showFreeBadge %}
-                        <sl-badge variant="neutral" pill itemprop="isAccessibleForFree" content="true">Free Event</sl-badge>
+                        <sl-badge variant="neutral" pill itemprop="isAccessibleForFree" content="true">Free of charge</sl-badge>
                       {% endif %}
                       {% if showCallForSpeakersBadge %}
                         <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
@@ -437,6 +438,23 @@ layout: layouts/base.liquid
       <label for="filter-attendance-in-person">In person</label>
     </div>
 
+  </fieldset>
+
+  <!-- Filter by free or not -->
+  <fieldset class="checkbox-group filter flow flow-tight">
+  
+    <legend class="text-muted">Ticket cost</legend>
+  
+    <div class="checkbox">
+      <input type="checkbox" x-model="$store.filters.isFree" @change="$store.filters.filterEvents()" value="true" id="filter-free" class="filter-option">
+      <label for="filter-free">Free of charge</label>
+    </div>
+  
+    <div class="checkbox">
+      <input type="checkbox" x-model="$store.filters.isPaid" @change="$store.filters.filterEvents()" value="false" id="filter-paid" class="filter-option">
+      <label for="filter-paid">Paid</label>
+    </div>
+  
   </fieldset>
 
   <div class="checkbox">

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -364,16 +364,19 @@ layout: layouts/base.liquid
                     <!-- End .event__children -->
                   {% endif %}
                   {% assign currentDate = 'now' | date: '%Y-%m-%dT%H:%M:%S%z' %}
-                  {% if event.callForSpeakers %}
-                    {% if event.callForSpeakersClosingDate == null or event.callForSpeakersClosingDate >= currentDate %}
-                      <div class="event__badges">
-                        <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
-                        {% if event.callForSpeakersClosingDate != null %}
-                          <small class="text-muted">Closes: {{ event.callForSpeakersClosingDate | localizeDate: "MMMM D" }}</small>
-                        {% endif %}
-                      </div>
+                  <div class="event__badges">
+                    {% if event.isFree %}
+                    <sl-badge variant="neutral" pill>Free Event</sl-badge>
                     {% endif %}
-                  {% endif %}
+                    {% if event.callForSpeakers %}
+                      {% if event.callForSpeakersClosingDate == null or event.callForSpeakersClosingDate >= currentDate %}
+                          <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
+                          {% if event.callForSpeakersClosingDate != null %}
+                            <small class="text-muted">Closes: {{ event.callForSpeakersClosingDate | localizeDate: "MMMM D" }}</small>
+                          {% endif %}
+                      {% endif %}
+                    {% endif %}
+                  </div>
                 </article>
                 <!-- End .event -->
               {% endif %}

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -372,7 +372,7 @@ layout: layouts/base.liquid
                   {% if showCallForSpeakersBadge or showFreeBadge %}
                     <div class="event__badges">
                       {% if showFreeBadge %}
-                        <sl-badge variant="neutral" pill>Free Event</sl-badge>
+                        <sl-badge variant="neutral" pill itemprop="isAccessibleForFree" content="true">Free Event</sl-badge>
                       {% endif %}
                       {% if showCallForSpeakersBadge %}
                         <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>

--- a/src/index.liquid
+++ b/src/index.liquid
@@ -364,19 +364,24 @@ layout: layouts/base.liquid
                     <!-- End .event__children -->
                   {% endif %}
                   {% assign currentDate = 'now' | date: '%Y-%m-%dT%H:%M:%S%z' %}
-                  <div class="event__badges">
-                    {% if event.isFree %}
-                    <sl-badge variant="neutral" pill>Free Event</sl-badge>
-                    {% endif %}
-                    {% if event.callForSpeakers %}
-                      {% if event.callForSpeakersClosingDate == null or event.callForSpeakersClosingDate >= currentDate %}
-                          <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
-                          {% if event.callForSpeakersClosingDate != null %}
-                            <small class="text-muted">Closes: {{ event.callForSpeakersClosingDate | localizeDate: "MMMM D" }}</small>
-                          {% endif %}
+                  {% assign hasCallForSpeakers = event.callForSpeakers %}
+                  {% assign callForSpeakersClosingDateValid = event.callForSpeakersClosingDate == null or event.callForSpeakersClosingDate >= currentDate %}
+                  {% assign showCallForSpeakersBadge = hasCallForSpeakers and callForSpeakersClosingDateValid %}
+                  {% assign showFreeBadge = event.isFree %}
+                  
+                  {% if showCallForSpeakersBadge or showFreeBadge %}
+                    <div class="event__badges">
+                      {% if showFreeBadge %}
+                        <sl-badge variant="neutral" pill>Free Event</sl-badge>
                       {% endif %}
-                    {% endif %}
-                  </div>
+                      {% if showCallForSpeakersBadge %}
+                        <sl-badge variant="success" pill pulse>Call for speakers</sl-badge>
+                        {% if event.callForSpeakersClosingDate != null %}
+                          <small class="text-muted">Closes: {{ event.callForSpeakersClosingDate | localizeDate: "MMMM D" }}</small>
+                        {% endif %}
+                      {% endif %}
+                    </div>
+                  {% endif %}
                 </article>
                 <!-- End .event -->
               {% endif %}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -43,6 +43,8 @@ if (window.location.pathname === "/") {
       cfsClosed: false,
       attendanceOnline: false,
       attendanceOffline: false,
+      isFree: false,
+      isPaid: false,
       themes: true,
     };
 
@@ -89,12 +91,13 @@ if (window.location.pathname === "/") {
         const eventType = event.getAttribute("data-event-type");
         const eventAttendanceMode = event.getAttribute("data-event-attendancemode");
         const eventCfsStatus = event.getAttribute("data-event-cfs") !== null;
+        const eventIsFree = event.getAttribute("data-event-isfree") !== null;
 
         // If the 'themes' filter is false and the event type is 'theme', hide the event
         // If the 'themes' filter is true and the event type is 'theme', show the event
         if (eventType === "theme") {
           event.hidden = !Alpine.store("filters").themes;
-        } else {
+                } else {
           // Check if the event matches the attendance mode filter
           const matchesAttendanceMode =
             (!Alpine.store("filters").attendanceOnline &&
@@ -105,16 +108,20 @@ if (window.location.pathname === "/") {
             (Alpine.store("filters").attendanceOffline &&
               (eventAttendanceMode === "offline" ||
                 eventAttendanceMode === "mixed"));
-
+        
           // Check if the event matches the cfs filter
           const matchesCfs =
             (!Alpine.store("filters").cfsOpen &&
               !Alpine.store("filters").cfsClosed) ||
             (Alpine.store("filters").cfsOpen && eventCfsStatus) ||
             (Alpine.store("filters").cfsClosed && !eventCfsStatus);
-
+        
+          // Check if the event matches the isFree filter
+          const matchesIsFree =
+            !Alpine.store("filters").isFree || event.isFree;
+        
           // If the event matches all filter criteria, show the event; otherwise, hide it
-          event.hidden = !(matchesAttendanceMode && matchesCfs);
+          event.hidden = !(matchesAttendanceMode && matchesCfs && matchesIsFree);
         }
 
         // After filtering the events, check each month section

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -42,7 +42,7 @@
         align-items: center;
         border-top: 1px solid rgba(0,0,0,.08);
         display: flex;
-        gap: var(--space-2xs);
+        gap: var(--space-3xs);
         order: 6;
         padding: var(--space-xs) 0 0;
     }


### PR DESCRIPTION
Displays a new 'Free Event' badge on events that are free to attend, based on a new boolean `isFree` property in the event schema.

Allows events to be filtered to show:
- only free events
- only paid events
- both free and paid events (default)

Closes #78 