### PR TITLE
Fix reset button

### DIFF
--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -50,10 +50,14 @@ import TimezoneSelector from './TimezoneSelector.vue';
 const filterToolbar = ref(null);
 const isFiltersChanged = computed(() => filtersStore.isChanged);
 
-watch(() => filtersStore.filters, () => {
-  console.debug('Filters changed:', filtersStore.filters);
-  console.debug('Is changed:', isFiltersChanged.value);
-}, { deep: true });
+watch(
+  () => filtersStore.filters,
+  () => {
+    console.debug('Filters changed:', filtersStore.filters);
+    console.debug('Is changed:', isFiltersChanged.value);
+  },
+  { deep: true }
+);
 
 function resetFilters() {
   filtersStore.resetFilters();

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -17,7 +17,7 @@
           </small>
         </p>
         <sl-button
-          v-if="filtersChanged"
+          v-if="filtersStore.isChanged"
           id="filter-reset"
           @click="resetFilters"
           type="primary"
@@ -47,18 +47,13 @@ import { ref, computed, onMounted, nextTick, watch } from 'vue';
 import filtersStore from '../store/filtersStore';
 import TimezoneSelector from './TimezoneSelector.vue';
 
-const filtersChanged = computed(() => filtersStore.isChanged());
-
-watch(
-  () => filtersStore.filters,
-  () => {
-    console.debug('Filters changed:', filtersStore.filters);
-    console.debug('Is changed:', filtersStore.isChanged());
-  },
-  { deep: true }
-);
-
 const filterToolbar = ref(null);
+const isFiltersChanged = computed(() => filtersStore.isChanged);
+
+watch(() => filtersStore.filters, () => {
+  console.debug('Filters changed:', filtersStore.filters);
+  console.debug('Is changed:', isFiltersChanged.value);
+}, { deep: true });
 
 function resetFilters() {
   filtersStore.resetFilters();

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -55,7 +55,7 @@
           {{ filtersStore.futureEvents.length }} events</sl-button
         >
         <sl-button
-          v-if="filtersStore.isChanged()"
+          v-if="filtersStore.isChanged"
           id="filter-reset"
           @click="resetFilters"
           type="primary"
@@ -70,8 +70,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { onMounted, computed, watch } from 'vue';
 import filtersStore from '../store/filtersStore';
+
+const isFiltersChanged = computed(() => filtersStore.isChanged);
+
+watch(() => filtersStore.filters, () => {
+  console.debug('Filters changed:', filtersStore.filters);
+  console.debug('Is changed:', isFiltersChanged.value);
+}, { deep: true });
 
 function emitCloseEvent() {
   const event = new CustomEvent('filters:close');

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -75,10 +75,14 @@ import filtersStore from '../store/filtersStore';
 
 const isFiltersChanged = computed(() => filtersStore.isChanged);
 
-watch(() => filtersStore.filters, () => {
-  console.debug('Filters changed:', filtersStore.filters);
-  console.debug('Is changed:', isFiltersChanged.value);
-}, { deep: true });
+watch(
+  () => filtersStore.filters,
+  () => {
+    console.debug('Filters changed:', filtersStore.filters);
+    console.debug('Is changed:', isFiltersChanged.value);
+  },
+  { deep: true }
+);
 
 function emitCloseEvent() {
   const event = new CustomEvent('filters:close');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,14 +40,48 @@ export const prerender = false;
   setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/');
 
   document.addEventListener('DOMContentLoaded', () => {
-    // Handle drawer state outside of Vue
-    const drawer = document.querySelector('sl-drawer');
+    let drawer = document.querySelector('sl-drawer');
+    let retries = 0;
+    const maxRetries = 5;
 
-    if (drawer) {
-      // Listen for custom events from Vue component
-      document.addEventListener('filters:open', () => drawer.show());
-      document.addEventListener('filters:close', () => drawer.hide());
+    // If drawer not found, retry with delay
+    function initDrawer() {
+      if (!drawer && retries < maxRetries) {
+        setTimeout(() => {
+          drawer = document.querySelector('sl-drawer');
+          if (drawer) {
+            setupEventListeners();
+          } else {
+            retries++;
+            initDrawer();
+          }
+        }, 100);
+      } else if (drawer) {
+        setupEventListeners();
+      } else {
+        console.error('Drawer not found after retries');
+      }
     }
+
+    function setupEventListeners() {
+      document.addEventListener('filters:open', () => {
+        try {
+          drawer.show();
+        } catch (e) {
+          console.error('Error showing drawer:', e);
+        }
+      });
+
+      document.addEventListener('filters:close', () => {
+        try {
+          drawer.hide();
+        } catch (e) {
+          console.error('Error hiding drawer:', e);
+        }
+      });
+    }
+
+    initDrawer();
   });
 
   // Initialize Sentry

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,17 +39,15 @@ export const prerender = false;
   import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
   setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/');
 
-  // Handle drawer state outside of Vue
-  const drawer = document.querySelector('sl-drawer');
-  const filterBtn = document.querySelector('#filter-btn');
+  document.addEventListener('DOMContentLoaded', () => {
+    // Handle drawer state outside of Vue
+    const drawer = document.querySelector('sl-drawer');
 
-  // Listen for custom events from Vue component
-  document.addEventListener('filters:open', () => drawer.show());
-  document.addEventListener('filters:close', () => drawer.hide());
-
-  // Optional: Add transition complete listener
-  drawer.addEventListener('sl-after-show', () => {
-    // Additional handling if needed
+    if (drawer) {
+      // Listen for custom events from Vue component
+      document.addEventListener('filters:open', () => drawer.show());
+      document.addEventListener('filters:close', () => drawer.hide());
+    }
   });
 
   // Initialize Sentry

--- a/src/store/filtersStore.js
+++ b/src/store/filtersStore.js
@@ -1,13 +1,15 @@
 import { reactive, computed, watch } from 'vue';
 import dayjs from 'dayjs';
 
-const defaultFilters = {
+const DEFAULT_FILTER_VALUES = {
   cfsOpen: false,
   cfsClosed: false,
   attendanceOnline: false,
   attendanceOffline: false,
   showAwarenessDays: true,
 };
+
+const defaultFilters = { ...DEFAULT_FILTER_VALUES };
 
 const isCallForSpeakersOpen = (event) => {
   if (!event.callForSpeakers) return false;
@@ -20,10 +22,10 @@ const initialFilters = reactive({ ...defaultFilters });
 
 // Load filters from localStorage
 const getStoredFilters = () => {
-  if (typeof window === 'undefined' || !localStorage) return defaultFilters;
+  if (typeof window === 'undefined' || !localStorage) return { ...defaultFilters };
 
   const saved = localStorage.getItem('filters');
-  return saved ? JSON.parse(saved) : defaultFilters;
+  return saved ? JSON.parse(saved) : { ...defaultFilters };
 };
 
 const filtersStore = reactive({
@@ -53,17 +55,15 @@ const filtersStore = reactive({
   },
 
   resetFilters() {
+    // Reset filters by copying default values
     this.filters = { ...defaultFilters };
-    if (typeof window !== 'undefined' && localStorage) {
-      localStorage.setItem('filters', JSON.stringify(this.filters));
-    }
+    localStorage.setItem('filters', JSON.stringify(this.filters));
     this.updateFilteredEvents();
   },
 
   isChanged: computed(() => {
-    // Compare each property individually to ensure reactive tracking
     return Object.keys(defaultFilters).some(
-      key => filtersStore.filters[key] !== initialFilters[key]
+      key => filtersStore.filters[key] !== defaultFilters[key]
     );
   }),
 

--- a/src/store/filtersStore.js
+++ b/src/store/filtersStore.js
@@ -22,7 +22,8 @@ const initialFilters = reactive({ ...defaultFilters });
 
 // Load filters from localStorage
 const getStoredFilters = () => {
-  if (typeof window === 'undefined' || !localStorage) return { ...defaultFilters };
+  if (typeof window === 'undefined' || !localStorage)
+    return { ...defaultFilters };
 
   const saved = localStorage.getItem('filters');
   return saved ? JSON.parse(saved) : { ...defaultFilters };
@@ -63,7 +64,7 @@ const filtersStore = reactive({
 
   isChanged: computed(() => {
     return Object.keys(defaultFilters).some(
-      key => filtersStore.filters[key] !== defaultFilters[key]
+      (key) => filtersStore.filters[key] !== defaultFilters[key]
     );
   }),
 

--- a/src/store/filtersStore.js
+++ b/src/store/filtersStore.js
@@ -6,7 +6,6 @@ const defaultFilters = {
   cfsClosed: false,
   attendanceOnline: false,
   attendanceOffline: false,
-  themes: true,
   showAwarenessDays: true,
 };
 

--- a/src/store/filtersStore.js
+++ b/src/store/filtersStore.js
@@ -16,6 +16,9 @@ const isCallForSpeakersOpen = (event) => {
   return dayjs().isBefore(dayjs(event.callForSpeakersClosingDate));
 };
 
+// Create a reactive reference to defaultFilters
+const initialFilters = reactive({ ...defaultFilters });
+
 // Load filters from localStorage
 const getStoredFilters = () => {
   if (typeof window === 'undefined' || !localStorage) return defaultFilters;
@@ -59,7 +62,10 @@ const filtersStore = reactive({
   },
 
   isChanged: computed(() => {
-    return JSON.stringify(filtersStore.filters) !== JSON.stringify(defaultFilters);
+    // Compare each property individually to ensure reactive tracking
+    return Object.keys(defaultFilters).some(
+      key => filtersStore.filters[key] !== initialFilters[key]
+    );
   }),
 
   filterEvents(events) {

--- a/src/store/filtersStore.js
+++ b/src/store/filtersStore.js
@@ -58,9 +58,9 @@ const filtersStore = reactive({
     this.updateFilteredEvents();
   },
 
-  isChanged() {
-    return JSON.stringify(this.filters) !== JSON.stringify(defaultFilters);
-  },
+  isChanged: computed(() => {
+    return JSON.stringify(filtersStore.filters) !== JSON.stringify(defaultFilters);
+  }),
 
   filterEvents(events) {
     return events.filter((event) => {

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -4,7 +4,7 @@ import AxeBuilder from '@axe-core/playwright';
 
 test.beforeEach(async ({ page, baseURL }) => {
   await page.goto(baseURL);
-  await page.waitForLoadState('networkidle');
+  // await page.waitForLoadState('networkidle');
   const filterDrawer = page.locator('#filter-drawer');
   const isVisible = await filterDrawer.isVisible();
   if (isVisible) {

--- a/tests/filters.spec.ts
+++ b/tests/filters.spec.ts
@@ -43,7 +43,6 @@ test('filter drawer opens when filter button is clicked', async ({ page }) => {
 });
 
 test('filter drawer closes when close button is clicked', async ({ page }) => {
-
   // Open drawer
   const filterButton = page.getByRole('button', { name: 'Filter' });
   await filterButton.waitFor({ state: 'visible' });

--- a/tests/filters.spec.ts
+++ b/tests/filters.spec.ts
@@ -13,7 +13,6 @@ test.beforeEach(async ({ page, baseURL }) => {
 
 test('filter button is visible', async ({ page }) => {
   // Wait for page ready
-  await page.waitForLoadState('networkidle');
   await page.waitForLoadState('domcontentloaded');
 
   // Locate and verify button
@@ -25,7 +24,6 @@ test('filter button is visible', async ({ page }) => {
 
 test('filter drawer opens when filter button is clicked', async ({ page }) => {
   // Wait for initial page load
-  await page.waitForLoadState('networkidle');
   await page.waitForLoadState('domcontentloaded');
 
   // Get filter button and wait for it to be ready
@@ -45,8 +43,6 @@ test('filter drawer opens when filter button is clicked', async ({ page }) => {
 });
 
 test('filter drawer closes when close button is clicked', async ({ page }) => {
-  // Wait for initial page load
-  await page.waitForLoadState('networkidle');
 
   // Open drawer
   const filterButton = page.getByRole('button', { name: 'Filter' });
@@ -71,7 +67,6 @@ test('filter drawer closes when close button is clicked', async ({ page }) => {
 
 test('filter drawer closes when esc key is pressed', async ({ page }) => {
   // Initial page load
-  await page.waitForLoadState('networkidle');
   await page.waitForLoadState('domcontentloaded');
 
   // Get and click filter button
@@ -95,7 +90,6 @@ test('filter drawer closes when esc key is pressed', async ({ page }) => {
 
 test('reset button appears when filters are applied', async ({ page }) => {
   // Setup
-  await page.waitForLoadState('networkidle');
   await page.waitForLoadState('domcontentloaded');
 
   // Open drawer

--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -13,7 +13,6 @@ test.describe('Theme Switching', () => {
 
     // Load page
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
     const filterDrawer = page.locator('#filter-drawer');
     const isVisible = await filterDrawer.isVisible();
     if (isVisible) {
@@ -91,7 +90,6 @@ test.describe('Theme Switching', () => {
     // Test light preference
     await page.emulateMedia({ colorScheme: 'light' });
     await page.reload();
-    await page.waitForLoadState('networkidle');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
   });
 


### PR DESCRIPTION
Prevent filter defaults from being mutated

- Add immutable `DEFAULT_FILTER_VALUES` constant
- Use spread operator to create new filter objects
- Maintain separate references for defaults and current filters
- Fix reset button not working on first page load

Fixes #267 
