### PR TITLE
Fix Schema

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -79,7 +79,7 @@ const formatDate = (dateString) => {
     itemtype="https://schema.org/Event"
     :data-event-type="event.type"
   >
-    <h3 class="event__title">
+    <h3 class="event__title" itemprop="name">
       <a v-if="event.website" :href="event.website" itemprop="url">{{
         event.title
       }}</a>
@@ -88,7 +88,6 @@ const formatDate = (dateString) => {
 
     <EventDate :event="event" />
     <EventDelivery
-      v-if="event.attendanceMode && event.attendanceMode !== 'none'"
       :attendanceMode="event.attendanceMode"
       :location="event.location"
     />

--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -8,6 +8,7 @@ const ATTENDANCE_MODES = {
   ONLINE: 'online',
   OFFLINE: 'offline',
   MIXED: 'mixed',
+  NONE: 'none',
 };
 </script>
 
@@ -25,8 +26,9 @@ import { computed } from 'vue';
 const props = defineProps({
   attendanceMode: {
     type: String,
-    required: true,
-    validator: (value) => Object.values(ATTENDANCE_MODES).includes(value),
+    required: false,
+    default: ATTENDANCE_MODES.NONE,
+    validator: (value) => !value || Object.values(ATTENDANCE_MODES).includes(value),
   },
   location: {
     type: String,
@@ -83,5 +85,17 @@ const displayLocation = computed(() => props.location || 'International');
         Online
       </span>
     </div>
+
+    <div
+      v-else-if="attendanceMode === ATTENDANCE_MODES.NONE"
+    >
+      <span class="event__location">
+        <i class="fa-solid fa-fw fa-location-dot"></i>
+        <span itemprop="location" itemscope itemtype="https://schema.org/Place">
+          {{ displayLocation }}
+        </span>
+      </span>
+    </div>
+
   </div>
 </template>

--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -28,7 +28,8 @@ const props = defineProps({
     type: String,
     required: false,
     default: ATTENDANCE_MODES.NONE,
-    validator: (value) => !value || Object.values(ATTENDANCE_MODES).includes(value),
+    validator: (value) =>
+      !value || Object.values(ATTENDANCE_MODES).includes(value),
   },
   location: {
     type: String,
@@ -86,9 +87,7 @@ const displayLocation = computed(() => props.location || 'International');
       </span>
     </div>
 
-    <div
-      v-else-if="attendanceMode === ATTENDANCE_MODES.NONE"
-    >
+    <div v-else-if="attendanceMode === ATTENDANCE_MODES.NONE">
       <span class="event__location">
         <i class="fa-solid fa-fw fa-location-dot"></i>
         <span itemprop="location" itemscope itemtype="https://schema.org/Place">
@@ -96,6 +95,5 @@ const displayLocation = computed(() => props.location || 'International');
         </span>
       </span>
     </div>
-
   </div>
 </template>

--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -43,6 +43,16 @@ const props = defineProps({
  * @returns {string} Location to display
  */
 const displayLocation = computed(() => props.location || 'International');
+
+/**
+ * Determines which icon to show based on location
+ * @returns {string} Icon class name
+ */
+const locationIcon = computed(() =>
+  displayLocation.value === 'International'
+    ? 'fa-solid fa-fw fa-globe'
+    : 'fa-solid fa-fw fa-location-dot'
+);
 </script>
 
 <template>
@@ -89,7 +99,7 @@ const displayLocation = computed(() => props.location || 'International');
 
     <div v-else-if="attendanceMode === ATTENDANCE_MODES.NONE">
       <span class="event__location">
-        <i class="fa-solid fa-fw fa-location-dot"></i>
+        <i :class="locationIcon"></i>
         <span itemprop="location" itemscope itemtype="https://schema.org/Place">
           {{ displayLocation }}
         </span>


### PR DESCRIPTION
Enhancements to event attendance modes:

* [`src/components/EventDelivery.vue`](diffhunk://#diff-9f4807d952df4636bb1f6e5458c0818143542b7e071d4b3a5202bd57680472e6R11): Added a new attendance mode `NONE` to the `ATTENDANCE_MODES` constant and updated the `attendanceMode` prop to be optional with a default value of `NONE`. The validator was also updated to handle the new mode. [[1]](diffhunk://#diff-9f4807d952df4636bb1f6e5458c0818143542b7e071d4b3a5202bd57680472e6R11) [[2]](diffhunk://#diff-9f4807d952df4636bb1f6e5458c0818143542b7e071d4b3a5202bd57680472e6L28-R32)
* [`src/components/EventDelivery.vue`](diffhunk://#diff-9f4807d952df4636bb1f6e5458c0818143542b7e071d4b3a5202bd57680472e6R89-R97): Added a new section to display the location when the attendance mode is `NONE`.

HTML structure improvements:

* [`src/components/Event.vue`](diffhunk://#diff-11b966f641b3a7f516aa637fcd4e22e07a5dd48091b9dac3ba9d10ed7f689ea4L82-R82): Added the `itemprop="name"` attribute to the event title.
* [`src/components/Event.vue`](diffhunk://#diff-11b966f641b3a7f516aa637fcd4e22e07a5dd48091b9dac3ba9d10ed7f689ea4L91): Removed the unnecessary `v-if` condition for `event.attendanceMode` in the `EventDelivery` component.