### PR TITLE
Refactor timezone calculation in Today.vue to use geo-based timezone

### DIFF
--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -42,12 +42,10 @@ import filtersStore from '../store/filtersStore';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-// Get the start of the day in the user's local timezone
+// Get the start of the day using the timezone from the edge function
 const today = computed(() => {
-  const userTz = userStore.useLocalTimezone
-    ? userStore.timezone || dayjs.tz.guess()
-    : dayjs.tz.guess(); // Always use local timezone if not using user-selected timezone
-  return dayjs().tz(userTz).startOf('day');
+  const timezone = userStore.geo?.timezone || 'UTC';
+  return dayjs().tz(timezone).startOf('day');
 });
 console.log('User timezone is:', userStore.timezone);
 console.log('Today is:', today.value.format('YYYY-MM-DD'));


### PR DESCRIPTION
This pull request includes a change to the `src/components/Today.vue` file to improve how the start of the day is calculated using the timezone from the edge function instead of the selected timezone preference.