### PR TITLE
Show speaker name

### DIFF
--- a/netlify/edge-functions/get-events.ts
+++ b/netlify/edge-functions/get-events.ts
@@ -34,6 +34,10 @@ interface Event {
   attendanceMode?: string;
   callForSpeakers?: boolean;
   type?: string;
+  speakers?: Array<{
+    _id: string;
+    name: string;
+  }>;
 }
 
 /**
@@ -135,7 +139,10 @@ async function fetchEventsFromSanity(
   try {
     // Fetch all non-draft events
     const events: Event[] = await client.fetch(`
-      *[_type == "event" && !(_id in path("drafts.**"))]
+      *[_type == "event" && !(_id in path("drafts.**"))] {
+        ...,
+        "speakers": speakers[]->{ _id, name }
+      }
     `);
 
     // Fetch children for each event and add CFS deadline events
@@ -144,7 +151,10 @@ async function fetchEventsFromSanity(
         // Fetch child events for each parent event
         const children: Event[] = await client.fetch(
           `
-        *[_type == "event" && parent._ref == $eventId] | order(dateStart asc)
+        *[_type == "event" && parent._ref == $eventId] {
+          ...,
+          "speakers": speakers[]->{ _id, name }
+        } | order(dateStart asc)
       `,
           { eventId: event._id }
         );

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -143,7 +143,7 @@ const enumeratedChildTypes = computed(() => {
       <p itemprop="description">{{ event.description }}</p>
     </details>
 
-    <details v-if="hasChildren" class="event__children flow">
+    <details v-if="hasChildren" class="event__children flow flow-m">
       <summary>
         <i class="icon fa-solid fa-caret-right"></i>
         Accessibility highlights: {{ enumeratedChildTypes }}

--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -56,16 +56,16 @@ const formatPreposition = computed(() => {
     qna: 'with',
     keynote: 'by',
     roundtable: 'with',
-  }
-  return prepositions[props.event.format] || 'by' // fallback to 'by' if format not found
-})
+  };
+  return prepositions[props.event.format] || 'by'; // fallback to 'by' if format not found
+});
 
 const speakersList = computed(() => {
-  if (!props.event.speakers?.length) return ''
+  if (!props.event.speakers?.length) return '';
   return props.event.speakers
-    .map(speaker => `<span itemprop="name">${speaker.name}</span>`)
-    .join(', ')
-})
+    .map((speaker) => `<span itemprop="name">${speaker.name}</span>`)
+    .join(', ');
+});
 </script>
 
 <template>
@@ -83,7 +83,13 @@ const speakersList = computed(() => {
     <div class="event__speakers text-muted text-small">
       {{ displayFormat }}
       <template v-if="event.speakers?.length">
-        {{ formatPreposition }} <span itemprop="performer" itemscope itemtype="https://schema.org/Person" v-html="speakersList"></span>
+        {{ formatPreposition }}
+        <span
+          itemprop="performer"
+          itemscope
+          itemtype="https://schema.org/Person"
+          v-html="speakersList"
+        ></span>
       </template>
     </div>
 
@@ -99,9 +105,7 @@ const speakersList = computed(() => {
         ·
         <EventDuration :event="event" />
       </template>
-      <template v-else>
-        Not yet scheduled
-      </template>
+      <template v-else> Not yet scheduled </template>
     </div>
   </article>
 </template>

--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -24,6 +24,7 @@ const props = defineProps({
  */
 const formatStrings = {
   talk: 'Talk',
+  tutorial: 'Tutorial',
   workshop: 'Workshop',
   webinar: 'Webinar',
   panel: 'Panel',
@@ -31,6 +32,7 @@ const formatStrings = {
   interview: 'Interview',
   qna: 'Q&A',
   keynote: 'Keynote',
+  roundtable: 'Roundtable',
 };
 
 /**
@@ -41,11 +43,34 @@ const formatStrings = {
 const displayFormat = computed(
   () => formatStrings[props.event.format] || props.event.format
 );
+
+const formatPreposition = computed(() => {
+  const prepositions = {
+    talk: 'by',
+    tutorial: 'by',
+    workshop: 'with',
+    webinar: 'with',
+    panel: 'with',
+    meetup: 'with',
+    interview: 'with',
+    qna: 'with',
+    keynote: 'by',
+    roundtable: 'with',
+  }
+  return prepositions[props.event.format] || 'by' // fallback to 'by' if format not found
+})
+
+const speakersList = computed(() => {
+  if (!props.event.speakers?.length) return ''
+  return props.event.speakers
+    .map(speaker => `<span itemprop="name">${speaker.name}</span>`)
+    .join(', ')
+})
 </script>
 
 <template>
   <article
-    class="child-event flow flow-3xs"
+    class="child-event"
     itemprop="subEvent"
     itemscope
     itemtype="https://schema.org/Event"
@@ -55,9 +80,15 @@ const displayFormat = computed(
       <span v-else>{{ event.title }}</span>
     </span>
 
+    <div class="event__speakers text-muted text-small">
+      {{ displayFormat }}
+      <template v-if="event.speakers?.length">
+        {{ formatPreposition }} <span itemprop="performer" itemscope itemtype="https://schema.org/Person" v-html="speakersList"></span>
+      </template>
+    </div>
+
     <div class="event__meta text-muted">
       <template v-if="event.scheduled">
-        {{ displayFormat }} <span>·</span>
         <EventDate
           :dateStart="event.dateStart"
           :dateEnd="event.dateEnd"
@@ -69,8 +100,14 @@ const displayFormat = computed(
         <EventDuration :event="event" />
       </template>
       <template v-else>
-        {{ displayFormat }} <span>·</span> Not yet scheduled
+        Not yet scheduled
       </template>
     </div>
   </article>
 </template>
+
+<style>
+.child-event__title {
+  margin-bottom: var(--p-space-3xs);
+}
+</style>

--- a/src/styles/utils/_flow.css
+++ b/src/styles/utils/_flow.css
@@ -1,3 +1,13 @@
+.flow {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.flow > * {
+  margin-block: 0;
+} 
+
 .flow > *:not(legend) + * {
   margin-block-start: var(--flow-space, 1em);
 }

--- a/src/styles/utils/_flow.css
+++ b/src/styles/utils/_flow.css
@@ -6,7 +6,7 @@
 
 .flow > * {
   margin-block: 0;
-} 
+}
 
 .flow > *:not(legend) + * {
   margin-block-start: var(--flow-space, 1em);


### PR DESCRIPTION
Fixes #318 

Enhancements to event handling:

* [`netlify/edge-functions/get-events.ts`](diffhunk://#diff-83bc4d84484218bb11eb360a8425b3de81f559af3333159954c3455352ded5aaR37-R40): Added a `speakers` property to the `Event` interface and updated the `fetchEventsFromSanity` function to include speaker details when fetching events. [[1]](diffhunk://#diff-83bc4d84484218bb11eb360a8425b3de81f559af3333159954c3455352ded5aaR37-R40) [[2]](diffhunk://#diff-83bc4d84484218bb11eb360a8425b3de81f559af3333159954c3455352ded5aaL138-R145) [[3]](diffhunk://#diff-83bc4d84484218bb11eb360a8425b3de81f559af3333159954c3455352ded5aaL147-R157)

Improvements to event display:

* [`src/components/EventChild.vue`](diffhunk://#diff-339dbd455341a1435a495dce3e7aa5c09d51baad4f420dc49fe53f55f4cbdc2fR27-R35): Added computed properties `formatPreposition` and `speakersList` to handle the display format and speakers list. Updated the template to display event speakers and adjusted the styling. [[1]](diffhunk://#diff-339dbd455341a1435a495dce3e7aa5c09d51baad4f420dc49fe53f55f4cbdc2fR27-R35) [[2]](diffhunk://#diff-339dbd455341a1435a495dce3e7aa5c09d51baad4f420dc49fe53f55f4cbdc2fR46-R73) [[3]](diffhunk://#diff-339dbd455341a1435a495dce3e7aa5c09d51baad4f420dc49fe53f55f4cbdc2fR83-L60) [[4]](diffhunk://#diff-339dbd455341a1435a495dce3e7aa5c09d51baad4f420dc49fe53f55f4cbdc2fL72-R113)
* [`src/components/Event.vue`](diffhunk://#diff-11b966f641b3a7f516aa637fcd4e22e07a5dd48091b9dac3ba9d10ed7f689ea4L146-R146): Added a new CSS class `flow-m` to improve the layout of child events.

Styling updates:

* [`src/styles/utils/_flow.css`](diffhunk://#diff-202e96ae69a6838847345ebdcfc07cebef3e3ff6c4da8fc41b4d3b6379627463R1-R10): Added a `.flow` class to standardize the flexbox layout for flow elements.