### PR TITLE
chore: update eslint-plugin-vue from 9.33.0 to 10.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "eslint-plugin-astro": "^1.5.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-playwright": "^2.2.2",
-        "eslint-plugin-vue": "^9.33.0",
+        "eslint-plugin-vue": "^10.5.1",
         "globals": "^16.3.0",
         "netlify-cli": "^23.12.1",
         "playwright-chromium": "^1.57.0",
@@ -8910,12 +8910,12 @@
       "license": "MIT"
     },
     "node_modules/@portabletext/block-tools": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-4.1.2.tgz",
-      "integrity": "sha512-DYr/q9nzptQoQNSGFHPmxI4IueIR+mzuLYPuT90PZYRrgdj/5vNI4pV+thGDCDzzI9zEkgJYYPKW6hdmVF8w0g==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@portabletext/block-tools/-/block-tools-4.1.3.tgz",
+      "integrity": "sha512-ow1n/2fKF4sZqbT2gjjmxUcrrHaDzKypbrqkGO/pmgWdD2TBFeDMGLRReRz3WtikcBLe4h+FvctfZwf2lMCAVA==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/sanity-bridge": "^1.2.5",
+        "@portabletext/sanity-bridge": "^1.2.6",
         "@portabletext/schema": "^2.0.0",
         "lodash": "^4.17.21"
       },
@@ -8923,17 +8923,17 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@sanity/types": "^4.18.0"
+        "@sanity/types": "^4.19.0"
       }
     },
     "node_modules/@portabletext/editor": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-3.0.7.tgz",
-      "integrity": "sha512-TjxqQhKAKaZdGF7z4YYPltqqMJLKMZYugQkSvbIsldFQyyUz25cr6/Y5v7ZitPUrL2r5atFKVZqNrElrnE0Heg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/editor/-/editor-3.0.9.tgz",
+      "integrity": "sha512-NxAFsBH52piERSVcYKQYUrMWyTCNHib6SXIOsDw4fP6aI7A9mh92hj3sKEefxTI8kmQatrKD6dDhWKRXm2YyVA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@portabletext/block-tools": "^4.1.2",
+        "@portabletext/block-tools": "^4.1.3",
         "@portabletext/keyboard-shortcuts": "^2.1.0",
         "@portabletext/patches": "^2.0.0",
         "@portabletext/schema": "^2.0.0",
@@ -8953,9 +8953,9 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/sanity-bridge": "^1.2.5",
-        "@sanity/schema": "^4.18.0",
-        "@sanity/types": "^4.18.0",
+        "@portabletext/sanity-bridge": "^1.2.6",
+        "@sanity/schema": "^4.19.0",
+        "@sanity/types": "^4.19.0",
         "react": "^18.3 || ^19",
         "rxjs": "^7.8.2"
       }
@@ -9003,9 +9003,9 @@
       }
     },
     "node_modules/@portabletext/plugin-character-pair-decorator": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-4.0.7.tgz",
-      "integrity": "sha512-U43wxtQlRiIwZwXTDNjeGzC/lBqfUaOyFzkvS/SdtEgJfSLMDXvcXGJNSgBUpqPB6GOBju10L5r4UkXP0MqP2g==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-character-pair-decorator/-/plugin-character-pair-decorator-4.0.9.tgz",
+      "integrity": "sha512-DrTK45InbU98iJHtiDAl/JlvTpW0HAVU04nQpasAZZak/PsYgewb0BYtI5YJkOpYEjcw+HDGjMTV3n4CsWFO2Q==",
       "license": "MIT",
       "dependencies": {
         "@xstate/react": "^6.0.0",
@@ -9017,14 +9017,14 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^3.0.7",
+        "@portabletext/editor": "^3.0.9",
         "react": "^18.3 || ^19"
       }
     },
     "node_modules/@portabletext/plugin-input-rule": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-1.0.7.tgz",
-      "integrity": "sha512-U3sUpTeCUv+5eVGWntJc+CZA0gGZ5gIvg80PZi1AF8696FIQN5NnOMy/n/BPqPYFxcjmb7qy2JBHYUhoVI68xg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-input-rule/-/plugin-input-rule-1.0.9.tgz",
+      "integrity": "sha512-D6/hm0E6qpoZ/FAy1WevhKCVfVJ3bv3PDJTenpvsOyMAmo79n3g4W7xZvIKBxVq04E7+tNhxX0jI5mAbgMqLyA==",
       "license": "MIT",
       "dependencies": {
         "@xstate/react": "^6.0.0",
@@ -9035,32 +9035,32 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^3.0.7",
+        "@portabletext/editor": "^3.0.9",
         "react": "^18.3 || ^19"
       }
     },
     "node_modules/@portabletext/plugin-markdown-shortcuts": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-4.0.7.tgz",
-      "integrity": "sha512-fFupKQsqbBHghvykDIqB10+gp5Mdg0Jjqp+aYM+FaHcg/n8WaIHpPBdMTZNSZYvWE42Dj80TqmGtrlFj1hHpYQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-markdown-shortcuts/-/plugin-markdown-shortcuts-4.0.9.tgz",
+      "integrity": "sha512-nU0S0WjW/Z2hDld/tgbZP1MMActI0pV8LrMqz6lozS3bF0mh38as8AiD9oas5UwR7FrOwFFDdBQejOUT6xFb2Q==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/plugin-character-pair-decorator": "^4.0.7",
-        "@portabletext/plugin-input-rule": "^1.0.7",
+        "@portabletext/plugin-character-pair-decorator": "^4.0.9",
+        "@portabletext/plugin-input-rule": "^1.0.9",
         "react-compiler-runtime": "1.0.0"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^3.0.7",
+        "@portabletext/editor": "^3.0.9",
         "react": "^18.3 || ^19"
       }
     },
     "node_modules/@portabletext/plugin-one-line": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-3.0.7.tgz",
-      "integrity": "sha512-5L3RYudOEV5QTNJ56GpK8x1IlmaMNglY31qKxUIsolHvssCGsVjKlsBQECn976jPhhxj3FMQgHtGQl9oudDXvg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-one-line/-/plugin-one-line-3.0.9.tgz",
+      "integrity": "sha512-ZgARq7AIhOM9Ucua18dKaMgHNgM9yTZN1A04GyZ+pq1+k2Y8ztTZRy84G24noWeSp7vUs+myqTKro1E6dGXuJQ==",
       "license": "MIT",
       "dependencies": {
         "react-compiler-runtime": "1.0.0"
@@ -9069,24 +9069,24 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^3.0.7",
+        "@portabletext/editor": "^3.0.9",
         "react": "^18.3 || ^19"
       }
     },
     "node_modules/@portabletext/plugin-typography": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-4.0.7.tgz",
-      "integrity": "sha512-qx4XlcxoE0YTbjc40JhksmxCCq2kqbyVMARA7jV5dm/5L6mZCvRTGBmTSL5vETxq9ARGbB8iOVMYvGHp1Gv4VQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@portabletext/plugin-typography/-/plugin-typography-4.0.9.tgz",
+      "integrity": "sha512-8ib5QZluBRlBqg0Bb9IuOKvbtBsgQSqkAK+Sp+VkrlpxBiHaAQLkouGTHfdFrqecmotuRtoqWKQ2TLHUZ8qCQg==",
       "license": "MIT",
       "dependencies": {
-        "@portabletext/plugin-input-rule": "^1.0.7",
+        "@portabletext/plugin-input-rule": "^1.0.9",
         "react-compiler-runtime": "1.0.0"
       },
       "engines": {
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@portabletext/editor": "^3.0.7",
+        "@portabletext/editor": "^3.0.9",
         "react": "^18.3 || ^19"
       }
     },
@@ -9107,9 +9107,9 @@
       }
     },
     "node_modules/@portabletext/sanity-bridge": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-1.2.5.tgz",
-      "integrity": "sha512-KWuvfNxw8NzKVYE7af7HSyO8d8BNGiMqV1gM4WUfATEYS9mX6hNoPojlPJNdoXk/dKUfiK7gM9Hewef/ZosaTw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-1.2.6.tgz",
+      "integrity": "sha512-metbbn76lwCxk0hzATOjBF9WoWrWmKkbqau+Q1VKHACj3JQ/dIEFD7dE7qutsCY/8Y8fKVVfCW/+HZXPTMe87w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9120,8 +9120,8 @@
         "node": ">=20.19 <22 || >=22.12"
       },
       "peerDependencies": {
-        "@sanity/schema": "^4.18.0",
-        "@sanity/types": "^4.18.0"
+        "@sanity/schema": "^4.19.0",
+        "@sanity/types": "^4.19.0"
       }
     },
     "node_modules/@portabletext/schema": {
@@ -17161,69 +17161,35 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.33.0.tgz",
-      "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.6.2.tgz",
+      "integrity": "sha512-nA5yUs/B1KmKzvC42fyD0+l9Yd+LtEpVhWRbXuDj0e+ZURcTtyRbMDWUeJmTAh2wC6jC83raS63anNM2YT3NPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "globals": "^13.24.0",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^6.0.15",
+        "postcss-selector-parser": "^7.1.0",
         "semver": "^7.6.3",
-        "vue-eslint-parser": "^9.4.3",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-vue/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "vue-eslint-parser": "^10.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-vue/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/eslint-plugin-vue/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -19632,9 +19598,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.0.0.tgz",
-      "integrity": "sha512-XtRG4SINt4dpqlnJvs70O2j6hH7H0X8fUzFsjMn1rwnETaxwp83HLNimXBjZ78MrKl3/d3/pkzDH0o0Lkxm37Q==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.0.1.tgz",
+      "integrity": "sha512-naDCyggtcBWANtIrjQEajhhBEuL9b0Zg4zmlWK2CzS6xCWSE39/vvf4LqnMjUAWHBhot4m9MHCM/Z+mfWhUkiA==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -45473,76 +45439,28 @@
       }
     },
     "node_modules/vue-eslint-parser": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
-      "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.2.0.tgz",
+      "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "debug": "^4.3.4",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
-        "esquery": "^1.4.0",
-        "lodash": "^4.17.21",
-        "semver": "^7.3.6"
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/vue-eslint-parser/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/vue-eslint-parser/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-astro": "^1.5.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-playwright": "^2.2.2",
-    "eslint-plugin-vue": "^9.33.0",
+    "eslint-plugin-vue": "^10.5.1",
     "globals": "^16.3.0",
     "netlify-cli": "^23.12.1",
     "playwright-chromium": "^1.57.0",


### PR DESCRIPTION
Update eslint-plugin-vue to major version 10 for improved Vue linting capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)