### PR TITLE
Extract isCallForSpeakersOpen to shared utility

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import dayjs from 'dayjs';
+import { isCallForSpeakersOpen } from '../utils/eventUtils';
 import EventDate from './EventDate.vue';
 import EventDelivery from './EventDelivery.vue';
 import EventChild from './EventChild.vue';
@@ -34,16 +34,9 @@ const hasChildren = computed(
 
 /**
  * Checks if call for speakers is currently open
- * Returns true if:
- * - Event has call for speakers enabled AND
- * - Either no closing date is set OR current date is before closing date
  * @returns {boolean} True if call for speakers is open
  */
-const isCallForSpeakersOpen = computed(() => {
-  if (!props.event.callForSpeakers) return false;
-  if (!props.event.callForSpeakersClosingDate) return true;
-  return dayjs().isBefore(dayjs(props.event.callForSpeakersClosingDate));
-});
+const callForSpeakersOpen = computed(() => isCallForSpeakersOpen(props.event));
 
 /**
  * Enumerates child event types and their counts
@@ -241,12 +234,12 @@ const speakerDisplay = computed(() => {
 
     <div
       class="event__badges"
-      v-if="isDedicatedToAccessibility || isCallForSpeakersOpen"
+      v-if="isDedicatedToAccessibility || callForSpeakersOpen"
     >
       <sl-badge pill variant="neutral" v-if="isDedicatedToAccessibility"
         >Dedicated to accessibility</sl-badge
       >
-      <sl-badge variant="success" pill v-if="isCallForSpeakersOpen"
+      <sl-badge variant="success" pill v-if="callForSpeakersOpen"
         >Call for speakers</sl-badge
       >
     </div>

--- a/src/store/filtersStore.ts
+++ b/src/store/filtersStore.ts
@@ -1,5 +1,5 @@
 import { reactive, computed, watch } from 'vue';
-import dayjs from 'dayjs';
+import { isCallForSpeakersOpen } from '../utils/eventUtils';
 
 interface Event {
   callForSpeakers?: boolean;
@@ -66,17 +66,6 @@ const DEFAULT_FILTER_VALUES: Filters = {
 };
 
 const defaultFilters: Filters = { ...DEFAULT_FILTER_VALUES };
-
-/**
- * Checks if the call for speakers is open for a given event.
- * @param event - The event to check.
- * @returns True if the call for speakers is open, false otherwise.
- */
-const isCallForSpeakersOpen = (event: Event): boolean => {
-  if (!event.callForSpeakers) return false;
-  if (!event.callForSpeakersClosingDate) return true;
-  return dayjs().isBefore(dayjs(event.callForSpeakersClosingDate));
-};
 
 // Create a reactive reference to defaultFilters
 const initialFilters = reactive({ ...defaultFilters });

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -1,0 +1,21 @@
+import dayjs from 'dayjs';
+
+interface EventWithCFS {
+  callForSpeakers?: boolean;
+  callForSpeakersClosingDate?: string;
+}
+
+/**
+ * Checks if the call for speakers is open for a given event.
+ * Returns true if:
+ * - Event has call for speakers enabled AND
+ * - Either no closing date is set OR current date is before closing date
+ *
+ * @param event - The event to check
+ * @returns True if the call for speakers is open, false otherwise
+ */
+export const isCallForSpeakersOpen = (event: EventWithCFS): boolean => {
+  if (!event.callForSpeakers) return false;
+  if (!event.callForSpeakersClosingDate) return true;
+  return dayjs().isBefore(dayjs(event.callForSpeakersClosingDate));
+};


### PR DESCRIPTION
## Summary
- Extract duplicated `isCallForSpeakersOpen` function from `Event.vue` and `filtersStore.ts` into a shared utility at `src/utils/eventUtils.ts`
- Improves code reuse and maintainability by having a single source of truth for this logic