### PR TITLE
Fix E2E tests to wait for Netlify deploy status

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,51 @@
 name: 'E2E Tests'
 
 on:
-  deployment_status:
+  pull_request:
 
 jobs:
   tests_e2e:
     name: Run end-to-end tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Only run when Netlify deployment succeeds
-    if: github.event.deployment_status.state == 'success'
     steps:
       - uses: actions/checkout@v4
+
+      - name: Wait for Netlify deploy
+        id: netlify
+        run: |
+          echo "Waiting for Netlify deploy preview..."
+          DEPLOY_URL="https://deploy-preview-${{ github.event.pull_request.number }}--eventua11y.netlify.app"
+
+          # Wait for Netlify commit status to be success
+          MAX_ATTEMPTS=60
+          ATTEMPT=0
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ATTEMPT=$((ATTEMPT + 1))
+            
+            # Check commit status via GitHub API
+            STATUS=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/statuses \
+              --jq '[.[] | select(.context | contains("netlify"))] | .[0].state // "pending"')
+            
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Netlify status is '$STATUS'"
+            
+            if [ "$STATUS" = "success" ]; then
+              echo "Netlify deploy complete!"
+              echo "url=$DEPLOY_URL" >> $GITHUB_OUTPUT
+              exit 0
+            elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "error" ]; then
+              echo "Netlify deploy failed!"
+              exit 1
+            fi
+            
+            sleep 10
+          done
+
+          echo "Timed out waiting for Netlify deploy"
+          exit 1
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/setup-node@v4
         with:
@@ -34,7 +68,7 @@ jobs:
       - name: Run tests
         run: npx playwright test --retries=1 --timeout=90000
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.netlify.outputs.url }}
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
- Revert from `deployment_status` trigger (which Netlify doesn't use) back to `pull_request`
- Poll GitHub commit statuses API to wait for Netlify deployment to complete before running tests
- Uses built-in `github.token` so no additional secrets are required

The previous approach using `deployment_status` didn't work because Netlify uses GitHub commit statuses, not the Deployments API.