### PR TITLE
Fix duplicate Sentry initialization causing Vue SDK warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@sentry/astro": "^10.30.0",
         "@sentry/cli": "^3.1.0",
         "@sentry/profiling-node": "^10.30.0",
-        "@sentry/vue": "^10.30.0",
         "@shoelace-style/shoelace": "^2.20.1",
         "dayjs": "^1.11.13",
         "dotenv": "^17.2.1",
@@ -14018,32 +14017,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@sentry/vue": {
-      "version": "10.34.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.34.0.tgz",
-      "integrity": "sha512-2c+s8pQKY/MTunwIgTsiMtq4c7cPYyhB1LFOZ/VJSQH8MLD7qzxG7ed8SOJ3NTnGn8a2TpW/vPtc3uh90zLH3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "10.34.0",
-        "@sentry/core": "10.34.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@tanstack/vue-router": "^1.64.0",
-        "pinia": "2.x || 3.x",
-        "vue": "2.x || 3.x"
-      },
-      "peerDependenciesMeta": {
-        "@tanstack/vue-router": {
-          "optional": true
-        },
-        "pinia": {
-          "optional": true
-        }
       }
     },
     "node_modules/@shikijs/core": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@sentry/astro": "^10.30.0",
     "@sentry/cli": "^3.1.0",
     "@sentry/profiling-node": "^10.30.0",
-    "@sentry/vue": "^10.30.0",
     "@shoelace-style/shoelace": "^2.20.1",
     "dayjs": "^1.11.13",
     "dotenv": "^17.2.1",

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -29,11 +29,20 @@ const { title } = Astro.props.frontmatter || Astro.props;
           : 'Eventua11y - accessibility and inclusive design events'
       }
     </title>
-    <meta property="og:title" content={title ? `${title} - Eventua11y` : 'Eventua11y'} />
+    <meta
+      property="og:title"
+      content={title ? `${title} - Eventua11y` : 'Eventua11y'}
+    />
     <meta property="og:site_name" content="Eventua11y" />
     <meta property="og:author" content="Matt Obee" />
-    <meta property="og:description" content="The calendar of digital accessibility and inclusive design events, curated by Matt Obee." />
-    <meta property="og:image" content="https://eventua11y.com/favicon/eventua11y_og_min.png" />
+    <meta
+      property="og:description"
+      content="The calendar of digital accessibility and inclusive design events, curated by Matt Obee."
+    />
+    <meta
+      property="og:image"
+      content="https://eventua11y.com/favicon/eventua11y_og_min.png"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={Astro.url} />
     <script is:inline>
@@ -71,7 +80,7 @@ const { title } = Astro.props.frontmatter || Astro.props;
       href="/favicon/favicon-16x16.png"
     />
     <link rel="manifest" href="/favicon/site.webmanifest" />
-    <link rel="canonical" href="https://eventua11y.com/">
+    <link rel="canonical" href="https://eventua11y.com/" />
     <script
       defer
       src="https://kit.fontawesome.com/6fc2948f48.js"
@@ -89,10 +98,8 @@ const { title } = Astro.props.frontmatter || Astro.props;
     </main>
 
     <TheFooter />
-    <script
-      src="https://cdn.usefathom.com/script.js"
-      data-site="XTSPEPUF"
-      defer></script>
+    <script src="https://cdn.usefathom.com/script.js" data-site="XTSPEPUF" defer
+    ></script>
   </body>
 </html>
 
@@ -113,17 +120,9 @@ const { title } = Astro.props.frontmatter || Astro.props;
 
   // Set base path for Shoelace assets
   import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
-  setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/');
+  setBasePath(
+    'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/'
+  );
 
   import '../scripts/main.ts';
-
-  // Initialize Sentry
-  import * as Sentry from "@sentry/vue";
-  
-  Sentry.init({
-    dsn: "https://63a5e1fe7a29dc3df46923bd277aa87e@o4505086842437632.ingest.us.sentry.io/4508463077588992",
-    integrations: [],
-    enabled: import.meta.env.PROD
-  });
-  
 </script>


### PR DESCRIPTION
## Summary

Fixes the Sentry console warning:
```
[@sentry/vue]: Misconfigured SDK. Vue specific errors will not be captured.
Update your `Sentry.init` call with an appropriate config option:
`app` (Application Instance - Vue 3) or `Vue` (Vue Constructor - Vue 2).
```

## Changes

- Remove redundant manual `@sentry/vue` initialization from `default.astro`
- Remove unused `@sentry/vue` dependency

## Root Cause

Sentry was being initialized twice:
1. Via the `@sentry/astro` integration in `astro.config.mjs` (correct)
2. Manually via `@sentry/vue` in `default.astro` without providing the Vue app instance (incorrect)

The `@sentry/astro` integration already handles client-side error tracking including Vue components, making the manual initialization redundant and misconfigured.