### PR TITLE
Fix GitHub security alerts: add workflow permissions and update dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,10 @@ name: 'E2E Tests'
 on:
   pull_request:
 
+permissions:
+  contents: read
+  statuses: read
+
 jobs:
   tests_e2e:
     name: Run end-to-end tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -6039,7 +6039,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
       "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -9170,7 +9169,6 @@
       "resolved": "https://registry.npmjs.org/@portabletext/sanity-bridge/-/sanity-bridge-2.0.2.tgz",
       "integrity": "sha512-LZhW/MWgS/3SRJ0yXkrYFWppRu0NqTktfoPceTTY/o4b8/sId0t9Aeb9XUtSvVP7UCsnvulxw4OP5+Hje4zpRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@portabletext/schema": "^2.1.1",
         "@sanity/schema": "^5.9.0",
@@ -11444,15 +11442,15 @@
       }
     },
     "node_modules/@sanity/import": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-4.1.1.tgz",
-      "integrity": "sha512-vCJ0pq3OS105h13J6b9aU3BVTrAmC38Y/NC/uJJ5WVFKB7lHogZ5tWOHLJ8yaaE5/WdKCM/jixyeUZ4CiOijNA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@sanity/import/-/import-4.1.2.tgz",
+      "integrity": "sha512-4X81TbdRnnxqkdUU5+chLRT8A0RpvrlJkFDeYgjkbJZSsng3d9AwudWPC0kqAcZbZrGhxdzeTsu2dQl0nNfIgA==",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.0",
         "@oclif/plugin-help": "^6.2.37",
         "@sanity/asset-utils": "^2.3.0",
-        "@sanity/cli-core": "^0.1.0-alpha.11",
+        "@sanity/cli-core": "^0.1.0-alpha.13",
         "@sanity/generate-help-url": "^4.0.0",
         "@sanity/mutator": "^5.8.1",
         "debug": "^4.4.3",
@@ -22253,7 +22251,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -22296,7 +22293,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -43312,7 +43308,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -48705,7 +48700,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
## Summary

- Adds explicit `permissions` block (`contents: read`, `statuses: read`) to `.github/workflows/tests.yml` to resolve code scanning alert #8 (missing workflow permissions)
- Updates `netlify-cli` and transitive dependencies via `package-lock.json`

## Remaining alerts

The 3 open Dependabot alerts (`minimatch`, `tar`, `qs`) are all transitive dependencies deep inside `eslint`, `netlify-cli`, `sanity`, and `@sentry/node`. They cannot be resolved without breaking upstream changes and are dev-only — none ship to production.