### PR TITLE
Only install Chromium in CI Playwright step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          timeout 5m npx playwright install --with-deps || (echo "Playwright installation timed out" && exit 1)
+          timeout 5m npx playwright install chromium --with-deps || (echo "Playwright installation timed out" && exit 1)
 
       - name: Run tests
         run: npx playwright test --retries=1 --timeout=90000


### PR DESCRIPTION
## Summary

- The CI workflow was running `playwright install --with-deps` which downloads **all** browsers (Chromium, Firefox, WebKit), but the project only tests against Chromium (Firefox and WebKit are commented out in `playwright.config.js`).
- Changed to `playwright install chromium --with-deps` to skip downloading unnecessary browser binaries and their system dependencies, reducing CI install time.