### PR TITLE
Prerender static pages and add site config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ dotenv.config();
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://eventua11y.com',
   output: 'server',
   adapter: netlify(),
   integrations: [

--- a/src/pages/accessibility.astro
+++ b/src/pages/accessibility.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import DefaultLayout from '../layouts/default.astro';
 ---
 

--- a/src/pages/curation-policy.astro
+++ b/src/pages/curation-policy.astro
@@ -1,4 +1,5 @@
 ---
+export const prerender = true;
 import DefaultLayout from '../layouts/default.astro';
 ---
 


### PR DESCRIPTION
## Summary

- **Prerender static pages**: Added `export const prerender = true` to `curation-policy.astro` and `accessibility.astro`. These pages contain only static content and don't need server-side rendering on every request, improving TTFB and reducing server load.
- **Add `site` config**: Set `site: 'https://eventua11y.com'` in the Astro config. This ensures `Astro.url` generates fully-qualified canonical URLs (already used in the layout's `og:url` meta tag) and populates `import.meta.env.SITE`.

## Testing

- Build succeeds with both pages correctly prerendered as static HTML
- Verify the accessibility and curation-policy pages render correctly on the deploy preview
- Verify `og:url` meta tag contains the correct full URL