### PR TITLE
Add custom 404 error page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,12 @@
+---
+export const prerender = true;
+import DefaultLayout from '../layouts/default.astro';
+---
+
+<DefaultLayout title="Page not found">
+  <div class="container readable py-l flow">
+    <h1>Page not found</h1>
+    <p>The page you're looking for doesn't exist or may have been moved.</p>
+    <p>Try browsing <a href="/">upcoming accessibility events</a> instead.</p>
+  </div>
+</DefaultLayout>


### PR DESCRIPTION
## Summary

- Added a custom `404.astro` page that uses the site's default layout for a consistent experience when visitors hit a missing route.
- The page is prerendered as static HTML (`/404.html`), which Netlify automatically serves for unmatched routes.

## Testing

- Build succeeds with the 404 page prerendered
- On the deploy preview, visit a non-existent URL (e.g. `/this-does-not-exist`) to verify the custom 404 page appears with the site's header, footer, and styling