### PR TITLE
Fix flaky 'limits past events to the last 12 months' test

### DIFF
--- a/tests/event-list.spec.ts
+++ b/tests/event-list.spec.ts
@@ -254,11 +254,12 @@ test.describe('Event List', () => {
       return;
     }
 
-    // Calculate the date 12 months ago
-    const today = new Date();
-    const twelveMonthsAgo = new Date(
-      today.setFullYear(today.getFullYear() - 1)
-    );
+    // Calculate the date 12 months ago, truncated to the start of the day (UTC)
+    // to avoid flaky failures caused by timezone differences between the test
+    // runner and event datetimes (see #502)
+    const twelveMonthsAgo = new Date();
+    twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
+    twelveMonthsAgo.setUTCHours(0, 0, 0, 0);
 
     // Check each event's date to ensure it's not older than 12 months
     // Note: We check the end date if available, as multi-day events that started


### PR DESCRIPTION
## Summary

- Truncates the 12-month cutoff to midnight UTC instead of using the exact runtime timestamp
- Prevents flaky failures when an event's datetime falls on the same calendar day as the cutoff but at an earlier hour due to timezone differences

## Root cause

The test computed "12 months ago" to the exact millisecond. When the CI runner executed at e.g. 22:39 UTC and an event started at 19:00 UTC on the same day, the event fell ~3.6 hours before the cutoff and failed the assertion — even though it's effectively within 12 months for any practical purpose.

## Fix

```diff
- const today = new Date();
- const twelveMonthsAgo = new Date(
-   today.setFullYear(today.getFullYear() - 1)
- );
+ const twelveMonthsAgo = new Date();
+ twelveMonthsAgo.setFullYear(twelveMonthsAgo.getFullYear() - 1);
+ twelveMonthsAgo.setUTCHours(0, 0, 0, 0);
```

Fixes #502