### PR TITLE
Fix accessibility, SEO, and code quality issues

### DIFF
--- a/netlify/edge-functions/get-events.ts
+++ b/netlify/edge-functions/get-events.ts
@@ -421,16 +421,12 @@ export default async function handler(
     console.log('[handler] Timezone debug:', timezoneDebug);
     console.log('[handler] Fetching events...');
     const events = await getEvents(userTimezone);
-    const eventsWithDebug = {
-      ...events,
-      debug: {
-        timezone: timezoneDebug,
-        events: events.debug,
-      },
-    };
     console.log('[handler] Events fetched successfully:', events.events.length);
 
-    return new Response(JSON.stringify(eventsWithDebug), {
+    // Strip debug data from the client response
+    const { debug: _debug, ...clientResponse } = events;
+
+    return new Response(JSON.stringify(clientResponse), {
       headers: {
         'Content-Type': 'application/json',
         'Cache-Control': 'public, max-age=300, stale-while-revalidate=60',

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="filters" class="py-xs-s">
+  <div id="filters" ref="filterToolbar" class="py-xs-s">
     <div class="container">
       <div class="filters__status">
         <p
@@ -46,7 +46,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, nextTick, watch } from 'vue';
+import { ref, onMounted, nextTick } from 'vue';
 import filtersStore from '../store/filtersStore';
 import TimezoneSelector from './TimezoneSelector.vue';
 
@@ -67,25 +67,6 @@ const filterToolbar = ref(null);
  * Used to ensure proper initialization of checked state
  */
 const awarenessDaysSwitch = ref(null);
-
-/**
- * Computed property to track filter changes
- * Used to show/hide reset button
- */
-const isFiltersChanged = computed(() => filtersStore.isChanged);
-
-/**
- * Watch filter changes for debugging
- * Logs current filters state and change status
- */
-watch(
-  () => filtersStore.filters,
-  () => {
-    console.debug('Filters changed:', filtersStore.filters);
-    console.debug('Is changed:', isFiltersChanged.value);
-  },
-  { deep: true }
-);
 
 /**
  * Resets all filters to default values

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -80,19 +80,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch, ref, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 import filtersStore from '../store/filtersStore';
-
-const isFiltersChanged = computed(() => filtersStore.isChanged);
-
-watch(
-  () => filtersStore.filters,
-  () => {
-    console.debug('Filters changed:', filtersStore.filters);
-    console.debug('Is changed:', isFiltersChanged.value);
-  },
-  { deep: true }
-);
 
 const awarenessDaysSwitch = ref(null);
 const booksSwitch = ref(null);

--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -51,8 +51,6 @@ const today = computed(() => {
   const timezone = userStore.geo?.timezone || 'UTC';
   return dayjs().tz(timezone).startOf('day');
 });
-console.log('User timezone is:', userStore.timezone);
-console.log('Today is:', today.value.format('YYYY-MM-DD'));
 const todaysEvents = ref([]);
 
 const updateTodaysEvents = () => {

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -80,7 +80,7 @@ const { title } = Astro.props.frontmatter || Astro.props;
       href="/favicon/favicon-16x16.png"
     />
     <link rel="manifest" href="/favicon/site.webmanifest" />
-    <link rel="canonical" href="https://eventua11y.com/" />
+    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).href} />
     <script
       defer
       src="https://kit.fontawesome.com/6fc2948f48.js"
@@ -117,11 +117,12 @@ const { title } = Astro.props.frontmatter || Astro.props;
   import '@shoelace-style/shoelace/dist/components/skeleton/skeleton.js';
   import '@shoelace-style/shoelace/dist/components/radio/radio.js';
   import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
+  import '@shoelace-style/shoelace/dist/components/divider/divider.js';
 
   // Set base path for Shoelace assets
   import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
   setBasePath(
-    'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.12.0/cdn/'
+    'https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/cdn/'
   );
 
   import '../scripts/main.ts';

--- a/src/pages/accessibility.astro
+++ b/src/pages/accessibility.astro
@@ -19,7 +19,7 @@ import DefaultLayout from '../layouts/default.astro';
     <h2>Standards</h2>
     <p property="accessibilitySummary">The goal is for each page of this website to meet the requirements of <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> 2.2 Level AA, an international standard for creating accessible online content. As of <time datetime="2025-01-02">2 January 2025</time>, all pages are thought to meet that standard.</p>
     <h2>Testing</h2>
-    <p>Updates are made to this website regularly and both manual and automated checks help identify accessibility issues before changes go live.<p>
+    <p>Updates are made to this website regularly and both manual and automated checks help identify accessibility issues before changes go live.</p>
     <ul>
       <li>During design, tools are used to test things like readability, use of color, and the contrast between foreground and background.</li>
       <li>When the code is being written, potential problems are flagged by a system called 'linting' so that they can be fixed immediately.</li>

--- a/src/pages/past-events.astro
+++ b/src/pages/past-events.astro
@@ -10,8 +10,8 @@ export const prerender = false;
 
 <DefaultLayout title="Past accessibility events">
   <div class="container grid">
-    <div id="events" role="region" aria-labelledby="upcoming-events-heading" class="py-l readable main-content">
-      <h1 class="sr-only">Past accessibility events</h1>
+    <div id="events" role="region" aria-labelledby="past-events-heading" class="py-l readable main-content">
+      <h1 id="past-events-heading" class="sr-only">Past accessibility events</h1>
       <EventList type="past" client:load />
     </div>
     <MonthNav id="month-nav" class="mb-l" client:load contentRegion='#events' />


### PR DESCRIPTION
## Summary

A batch of quick-win bug fixes found during codebase audit.

### Accessibility fixes
- **Unclosed `<p>` tag** on the accessibility statement page — malformed HTML that breaks document outline for screen readers
- **Mismatched `aria-labelledby`** on past-events page — pointed to `upcoming-events-heading` (doesn't exist), now correctly references `past-events-heading`

### SEO fixes
- **Canonical URL** was hardcoded to `https://eventua11y.com/` for every page — now uses the actual page pathname via `Astro.url.pathname` + `Astro.site`

### Bug fixes
- **Shoelace CDN base path** referenced version 2.12.0 but the installed package is 2.20.1 — icons and other CDN-loaded assets may have been broken or loading stale versions
- **Missing `sl-divider` import** — the component was used in TheHeader but never imported, so it was hidden by the `:not(:defined)` CSS rule
- **Broken `filterToolbar` IntersectionObserver** — the ref was declared but never bound to the `#filters` div, so the sticky `is-pinned` class was never applied

### Code quality
- **Remove `console.log`/`console.debug`** from Today.vue, FilterBar.vue, and Filters.vue — leaked user timezone data and filter state to browser console
- **Strip debug data from events API response** — was sending user geo-location, all request headers, and per-event processing info to every client. Server-side `console.log` retained for Netlify logs.
- Remove unused `computed`/`watch` imports from FilterBar.vue and Filters.vue after removing debug watchers