### PR TITLE
Remove dead code in getStartDateFormat() and fix stale JSDoc

### DIFF
--- a/src/components/EventDate.vue
+++ b/src/components/EventDate.vue
@@ -154,29 +154,36 @@ function isSameDay(
 }
 
 /**
- * Determines date format for start date based on event type:
- * - Single date: Full date with year (MMM D, YYYY)
- * - Multi-day: Month and day only (MMM D)
- * - Same-day: Full date and time (LLL)
- * @returns {string} Format pattern for dayjs
+ * Determines the dayjs format pattern for the start date.
+ *
+ * Date-only (LL, e.g. "January 15, 2026"):
+ *   - Awareness days/weeks (type === 'theme')
+ *   - CFS deadlines (isDeadline)
+ *   - All-day events (day)
+ *
+ * Date and time (LLL, e.g. "January 15, 2026 2:00 PM"):
+ *   - All other timed events
  */
-function getStartDateFormat() {
+function getStartDateFormat(): string {
   if (props.type === 'theme') return 'LL';
   if (props.isDeadline) return 'LL';
   if (props.day) return 'LL';
-
-  if (!props.dateEnd) return 'LLL';
   return 'LLL';
 }
 
 /**
- * Determines date format for end date based on event type:
- * - Same-day event: Time only (LT)
- * - Multi-day event: Full date with year (MMM D, YYYY)
- * - Awareness day: Full date (LL)
- * @returns {string} Format pattern for dayjs
+ * Determines the dayjs format pattern for the end date.
+ *
+ * Date-only (LL, e.g. "January 18, 2026"):
+ *   - All-day events (day)
+ *
+ * Time-only (LT, e.g. "5:00 PM"):
+ *   - Same-day events (avoids repeating the date from the start)
+ *
+ * Date and time (LLL, e.g. "January 18, 2026 5:00 PM"):
+ *   - Multi-day timed events
  */
-function getEndDateFormat() {
+function getEndDateFormat(): string {
   if (props.day) return 'LL';
   if (isSameDay(props.dateStart, props.dateEnd)) return 'LT';
   return 'LLL';


### PR DESCRIPTION
## Summary

Closes #510.

- Removes the vestigial `if (!props.dateEnd)` branch in `getStartDateFormat()` that returned the same value (`'LLL'`) as the fallthrough, making it dead code
- Updates the JSDoc comments on both `getStartDateFormat()` and `getEndDateFormat()` to accurately describe the current logic, format tokens, and examples
- Adds explicit `: string` return types to both functions

## Context

The dead branch was left behind in commit 8b854b4 ("Move times to the end of single-day event strings"), which removed the same-day start format branch below it but left the `!props.dateEnd` guard above it. The `getEndDateFormat()` JSDoc also still referenced `MMM D, YYYY` from v1 of the function when it actually returns `LLL`.

No behavioural changes — the rendered date output is identical before and after this change.