### PR TITLE
Fix events API cache header and Geo interface type safety

### DIFF
--- a/netlify/edge-functions/get-events.ts
+++ b/netlify/edge-functions/get-events.ts
@@ -428,7 +428,7 @@ export default async function handler(
     return new Response(JSON.stringify(clientResponse), {
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300, stale-while-revalidate=60',
+        'Cache-Control': 'private, max-age=300, stale-while-revalidate=60',
         Vary: 'Accept-Encoding',
       },
     });

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,9 +1,10 @@
 import { reactive } from 'vue';
 
 interface Geo {
-  country: string;
-  region: string;
-  city: string;
+  country?: string;
+  region?: string;
+  city?: string;
+  timezone?: string;
 }
 
 interface UserStore {


### PR DESCRIPTION
## Summary

Two small fixes identified during a timezone handling review:

- **Change `Cache-Control` on `/api/get-events` from `public` to `private`** — the response body contains timezone-specific event categorisation (today/future/past buckets) based on the user's IP-geolocated timezone, but `Vary` only includes `Accept-Encoding`. A shared CDN cache could serve one user's categorisation to a user in a different timezone. Marking as `private` restricts caching to the user's browser, which is the correct scope for a per-user response.

- **Add `timezone` to the `Geo` interface in `userStore.ts`** — components like `TimezoneSelector` and `Today` already access `userStore.geo?.timezone` at runtime, but the TypeScript interface didn't declare the field. Also makes all `Geo` fields optional (`?`) to match the server-side interface in `get-user-info.ts`, since Netlify geo data isn't guaranteed.

No behavioural changes — the first fix may improve correctness for users behind shared CDN nodes, and the second is purely a type safety improvement.