### PR TITLE
Filter Shoelace data:image spans from Sentry tracing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,7 +21,6 @@ export default defineConfig({
       devtools: false,
     }),
     sentry({
-      dsn: 'https://63a5e1fe7a29dc3df46923bd277aa87e@o4505086842437632.ingest.us.sentry.io/4508463077588992',
       sourceMapsUploadOptions: {
         project: 'eventua11y',
         authToken: SENTRY_AUTH_TOKEN,

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/astro';
+
+Sentry.init({
+  dsn: 'https://63a5e1fe7a29dc3df46923bd277aa87e@o4505086842437632.ingest.us.sentry.io/4508463077588992',
+  beforeSendSpan(span) {
+    // Filter out Shoelace's internal system icon fetches (data:image/svg+xml URLs)
+    // These are in-memory data URIs, not real network requests, and trigger
+    // false N+1 API call warnings in Sentry (EVENTUA11Y-R).
+    if (span.description && span.description.startsWith('data:image/')) {
+      return null;
+    }
+    return span;
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `sentry.client.config.js` with a `beforeSendSpan` hook that filters out `data:image/` spans, resolving the false-positive N+1 API call issue ([EVENTUA11Y-R](https://matt-obee.sentry.io/issues/EVENTUA11Y-R))
- Moves the Sentry DSN from `astro.config.mjs` to the client config file, following Sentry's recommended approach and removing a deprecation warning

## Context

Shoelace's internal "system" icon library resolves component icons (for radios, switches, menu items, etc.) by calling `fetch()` with `data:image/svg+xml,...` URIs. These are in-memory data URIs, not real network requests, but Sentry's fetch instrumentation records each one as an API call — triggering a false N+1 API Call performance issue that has been firing since January.

Fixes EVENTUA11Y-R