### PR TITLE
Load Google Fonts asynchronously to improve FCP

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -65,7 +65,15 @@ const { title } = Astro.props.frontmatter || Astro.props;
     <link
       href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=Roboto+Slab&display=swap"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=Roboto+Slab&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
     <link
       rel="apple-touch-icon"
       sizes="180x180"


### PR DESCRIPTION
## Summary

- Makes the Google Fonts stylesheet non-render-blocking using the `media="print"` / `onload` swap pattern
- Includes a `<noscript>` fallback so fonts still load without JS

## Context

After #520, Lighthouse reported FCP of 2.4s (red). The `<link rel="stylesheet">` for Google Fonts was blocking rendering — the browser waited for the font CSS to download before painting anything.

Since #520 already added metric-matched fallback `@font-face` declarations (`size-adjust`, `ascent-override`, etc.), the page can paint immediately with the fallback fonts and swap to the web fonts with minimal reflow when they arrive.

## Testing

- Build passes (`npm run build`)
- Run Lighthouse after deploying to verify FCP improvement
- Verify fonts still load correctly with and without JS