### PR TITLE
Add server-rendered placeholder for FilterBar to reduce CLS

### DIFF
--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -102,6 +102,9 @@ function toggleAwarenessDays(event) {
 onMounted(async () => {
   await nextTick();
 
+  // Remove the static placeholder now that the real FilterBar is mounted
+  document.getElementById('filters-placeholder')?.remove();
+
   // Initialize switch state with setTimeout
   setTimeout(() => {
     if (awarenessDaysSwitch.value) {

--- a/src/components/FilterBarPlaceholder.astro
+++ b/src/components/FilterBarPlaceholder.astro
@@ -1,0 +1,17 @@
+---
+/**
+ * Static placeholder that reserves space for the FilterBar before Vue hydrates.
+ * Mirrors the layout of FilterBar.vue so the page doesn't shift when the real
+ * component loads. Removed by FilterBar.vue on mount.
+ */
+---
+
+<div id="filters-placeholder" class="py-xs-s">
+  <div class="container">
+    <div class="filters__status">
+      <p class="filters__count text-muted">
+        <small>Loading events&hellip;</small>
+      </p>
+    </div>
+  </div>
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,6 +6,7 @@ import FilterBar from '../components/FilterBar.vue';
 import Filters from '../components/Filters.vue';
 import MonthNav from '../components/MonthNav.vue';
 import StaticEventList from '../components/StaticEventList.astro';
+import FilterBarPlaceholder from '../components/FilterBarPlaceholder.astro';
 
 // Disable prerendering to enable SSR
 export const prerender = false;
@@ -13,6 +14,7 @@ export const prerender = false;
 
 <DefaultLayout>
   <Today client:load />
+  <FilterBarPlaceholder />
   <FilterBar client:only="vue" />
   <Filters client:only="vue" />
   <div class="container grid">

--- a/src/styles/_filters.css
+++ b/src/styles/_filters.css
@@ -1,9 +1,10 @@
-#filters {
+#filters,
+#filters-placeholder {
   align-items: center;
   background-color: var(--s-color-background);
   border-bottom: 1px solid var(--s-color-border);
   margin-bottom: var(--p-space-s-l);
-  min-height: 3.5rem; /* Reserve space to reduce CLS before Vue hydration */
+  min-height: 3.5rem;
   position: sticky;
   top: -1px;
   z-index: 1;


### PR DESCRIPTION
## Summary

- Adds a static `FilterBarPlaceholder.astro` component that is server-rendered on the homepage, reserving the space the FilterBar will occupy
- The placeholder shows "Loading events..." in the same layout/styling as the real FilterBar
- When the Vue FilterBar mounts (`client:only="vue"`), it removes the placeholder via `document.getElementById('filters-placeholder')?.remove()`
- Shares the same CSS rules as `#filters` so dimensions match exactly

## Problem

The FilterBar uses `client:only="vue"` because it needs JS to function -- SSR-rendering it would show non-functional controls. But `client:only` produces zero server-side HTML, so when Vue hydrates and the toolbar appears, everything below it shifts down, contributing to the CLS score of 0.404.

## Files changed

| File | Change |
|------|--------|
| `src/components/FilterBarPlaceholder.astro` | New static placeholder component |
| `src/pages/index.astro` | Renders placeholder before the `client:only` FilterBar |
| `src/components/FilterBar.vue` | Removes placeholder on mount |
| `src/styles/_filters.css` | Applies `#filters` styling to `#filters-placeholder` too |