### PR TITLE
fix: prevent Netlify toolbar from causing false axe-core failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Run tests
         run: npx playwright test --retries=1 --timeout=90000
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.netlify.outputs.url }}
+          # Hide the Netlify Drawer toolbar so it doesn't inject an iframe
+          # that causes false-positive axe-core ARIA violations (#549)
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.netlify.outputs.url }}?ntl-drawer-state=hidden
 
       - name: Upload test results
         if: always()

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -12,8 +12,10 @@ import AxeBuilder from '@axe-core/playwright';
  */
 
 // Helper: run an axe scan scoped to WCAG 2.2 Level AA
+// Excludes iframes to avoid false positives from third-party toolbars (#549)
 async function runAxeScan(page: Page) {
   const results = await new AxeBuilder({ page })
+    .exclude('iframe')
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
     .analyze();
   return results;

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -32,6 +32,7 @@ test('footer is visible', async ({ page }) => {
 
 test('has no accessibility violations', async ({ page }) => {
   const accessibilityScanResults = await new AxeBuilder({ page })
+    .exclude('iframe')
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
     .analyze();
   expect(accessibilityScanResults.violations).toEqual([]);


### PR DESCRIPTION
## Summary

- Hide the Netlify Drawer toolbar in CI by appending `?ntl-drawer-state=hidden` to the deploy preview URL
- Exclude iframes from all axe-core scans as defense-in-depth

## Problem

The Netlify Drawer toolbar injects an iframe into deploy preview pages. axe-core scans cross-frame content by default and finds an `aria-required-children` violation in the toolbar's own HTML (`role="tablist"` with a `button` child instead of `tab`). This caused flaky CI failures unrelated to our code.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/tests.yml` | Append `?ntl-drawer-state=hidden` to `PLAYWRIGHT_TEST_BASE_URL` |
| `tests/accessibility.spec.ts` | Add `.exclude('iframe')` to `runAxeScan()` helper |
| `tests/events.spec.ts` | Add `.exclude('iframe')` to inline axe scan |

Fixes #549