### PR TITLE
Migrate sl-alert to wa-callout (Step 4)

### DIFF
--- a/src/components/EventList.vue
+++ b/src/components/EventList.vue
@@ -234,19 +234,19 @@ watch(
     </div>
 
     <!-- Error state -->
-    <sl-alert v-else-if="error" open variant="danger" class="my-xl">
+    <wa-callout v-else-if="error" variant="danger" class="my-xl">
       <wa-icon
         slot="icon"
         name="octagon-exclamation"
         variant="regular"
       ></wa-icon>
       {{ error }}
-    </sl-alert>
+    </wa-callout>
 
     <!-- No events state -->
-    <sl-alert
+    <wa-callout
       v-else-if="!loading && Object.keys(groupedEvents).length === 0"
-      open
+      variant="neutral"
       class="my-xl"
     >
       <wa-icon slot="icon" name="circle-info" variant="regular"></wa-icon>
@@ -255,7 +255,7 @@ watch(
           ? 'There are no past events to display.'
           : 'There are no upcoming events to display.'
       }}
-    </sl-alert>
+    </wa-callout>
 
     <!-- Events list -->
     <div :id="`${type}-events`" v-else class="flow flow-2xl">

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -138,7 +138,8 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
   import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
   import '@awesome.me/webawesome/dist/components/select/select.js';
   import '@awesome.me/webawesome/dist/components/option/option.js';
-  import '@shoelace-style/shoelace/dist/components/alert/alert.js';
+  // sl-alert migrated to wa-callout (Web Awesome)
+  import '@awesome.me/webawesome/dist/components/callout/callout.js';
   import '@shoelace-style/shoelace/dist/components/drawer/drawer.js';
   import '@shoelace-style/shoelace/dist/components/switch/switch.js';
   // sl-skeleton removed — replaced with native CSS skeleton in Skeleton.vue


### PR DESCRIPTION
## Summary
- Replace `sl-alert` with `wa-callout` in `EventList.vue` (error state and empty state)
- Swap Shoelace alert import for WA callout import in `default.astro`
- `wa-callout` has no `open` attribute (always visible), so it's dropped
- Info callout uses `variant="neutral"` since `wa-callout` defaults to `brand`

Part of the incremental Shoelace → Web Awesome migration (#543), Step 4.