### PR TITLE
Migrate sl-switch to wa-switch (Step 5)

### DIFF
--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -28,12 +28,12 @@
         </wa-button>
       </div>
       <div class="filters__controls d-flex gap-xs items-center">
-        <sl-switch
+        <wa-switch
           ref="awarenessDaysSwitch"
           :checked="filtersStore.filters.showAwarenessDays"
-          @sl-change="toggleAwarenessDays"
+          @change="toggleAwarenessDays"
           id="filter-show-awareness-days-bar"
-          >Awareness days</sl-switch
+          >Awareness days</wa-switch
         >
         <div class="group">
           <wa-button

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -37,26 +37,26 @@
       </div>
 
       <div class="flow flow-xs">
-        <sl-switch
+        <wa-switch
           ref="awarenessDaysSwitch"
           :checked="filtersStore.filters.showAwarenessDays"
-          @sl-change="toggleAwarenessDays"
+          @change="toggleAwarenessDays"
           id="filter-show-awareness-days-drawer"
-          >Show awareness days</sl-switch
+          >Show awareness days</wa-switch
         >
-        <sl-switch
+        <wa-switch
           ref="booksSwitch"
           :checked="filtersStore.filters.showBooks"
-          @sl-change="toggleBooks"
+          @change="toggleBooks"
           id="filter-show-books-drawer"
-          >Show Book Club</sl-switch
+          >Show Book Club</wa-switch
         >
-        <sl-switch
+        <wa-switch
           ref="deadlinesSwitch"
           :checked="filtersStore.filters.showDeadlines"
-          @sl-change="toggleDeadlines"
+          @change="toggleDeadlines"
           id="filter-show-deadlines-drawer"
-          >Show speaker deadlines</sl-switch
+          >Show speaker deadlines</wa-switch
         >
       </div>
       <div class="d-flex flex-col items-start gap-xs">

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -141,7 +141,8 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
   // sl-alert migrated to wa-callout (Web Awesome)
   import '@awesome.me/webawesome/dist/components/callout/callout.js';
   import '@shoelace-style/shoelace/dist/components/drawer/drawer.js';
-  import '@shoelace-style/shoelace/dist/components/switch/switch.js';
+  // sl-switch migrated to wa-switch (Web Awesome)
+  import '@awesome.me/webawesome/dist/components/switch/switch.js';
   // sl-skeleton removed — replaced with native CSS skeleton in Skeleton.vue
   import '@shoelace-style/shoelace/dist/components/radio/radio.js';
   import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -54,7 +54,8 @@ main {
     wa-dropdown-item,
     wa-icon,
     wa-option,
-    wa-select
+    wa-select,
+    wa-switch
   ):focus-visible,
 .masthead__logo > a:focus-visible {
   outline-color: var(--c-focus-ring-color);


### PR DESCRIPTION
## Summary
- Replace `sl-switch` with `wa-switch` in `FilterBar.vue` (1 instance) and `Filters.vue` (3 instances)
- Event handler changes from `@sl-change` to `@change` (WA uses native events)
- Swap Shoelace switch import for WA switch import in `default.astro`
- Add `wa-switch` to focus-visible exclusion list in `styles.css`

Part of the incremental Shoelace → Web Awesome migration (#543), Step 5.