### PR TITLE
Add 'Free' badge to free events

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -243,7 +243,11 @@ const speakerDisplay = computed(() => {
 
     <div
       class="event__badges"
-      v-if="isDedicatedToAccessibility || callForSpeakersOpen || event.isFree"
+      v-if="
+        isDedicatedToAccessibility ||
+        callForSpeakersOpen ||
+        (event.isFree && event.type !== 'theme')
+      "
     >
       <wa-badge pill variant="neutral" v-if="isDedicatedToAccessibility"
         >Dedicated to accessibility</wa-badge
@@ -255,7 +259,12 @@ const speakerDisplay = computed(() => {
         v-if="callForSpeakersOpen"
         >Call for speakers</wa-badge
       >
-      <wa-badge variant="neutral" pill v-if="event.isFree">Free</wa-badge>
+      <wa-badge
+        variant="neutral"
+        pill
+        v-if="event.isFree && event.type !== 'theme'"
+        >Free</wa-badge
+      >
     </div>
   </article>
   <div v-else class="event event--loading">Loading...</div>

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -191,12 +191,12 @@ const displayLocation = event.location || 'International';
         </details>
       )}
 
-      {(callForSpeakersOpen || event.isFree) && (
+      {(callForSpeakersOpen || (event.isFree && !isTheme)) && (
         <div class="event__badges">
           {callForSpeakersOpen && (
             <span class="badge badge--success">Call for speakers</span>
           )}
-          {event.isFree && <span class="badge">Free</span>}
+          {event.isFree && !isTheme && <span class="badge">Free</span>}
         </div>
       )}
     </article>


### PR DESCRIPTION
## Summary

- Displays a "Free" pill badge on event cards when `isFree` is true, using the existing `neutral` variant consistent with other badges
- Updated both the Vue client-side component (`Event.vue`) and the Astro noscript fallback (`StaticEvent.astro`)
- No schema or data changes required — the `isFree` boolean field is already present in the event type and populated from Sanity