### PR TITLE
Fix vertical alignment of website link in delivery listings

### DIFF
--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -46,27 +46,29 @@ const locationIcon = computed(() =>
 
 <template>
   <div class="event__delivery text-small">
-    <span
+    <div
       v-if="attendanceMode === ATTENDANCE_MODES.ONLINE"
-      class="event__online"
       itemprop="eventAttendanceMode"
       content="https://schema.org/OnlineEventAttendanceMode"
     >
-      <wa-icon name="laptop" auto-width></wa-icon>
-      Online
-    </span>
+      <span class="event__online">
+        <wa-icon name="laptop" auto-width></wa-icon>
+        Online
+      </span>
+    </div>
 
-    <span
+    <div
       v-else-if="attendanceMode === ATTENDANCE_MODES.OFFLINE"
-      class="event__location"
       itemprop="eventAttendanceMode"
       content="https://schema.org/OfflineEventAttendanceMode"
     >
-      <wa-icon name="location-dot"></wa-icon>
-      <span itemprop="location" itemscope itemtype="https://schema.org/Place">
-        {{ displayLocation }}
+      <span class="event__location">
+        <wa-icon name="location-dot"></wa-icon>
+        <span itemprop="location" itemscope itemtype="https://schema.org/Place">
+          {{ displayLocation }}
+        </span>
       </span>
-    </span>
+    </div>
 
     <div
       v-else-if="attendanceMode === ATTENDANCE_MODES.MIXED"


### PR DESCRIPTION
## Summary

- Fixes a vertical alignment bug where the "Event website" link dropped below the baseline for online and offline attendance modes in `EventDelivery.vue`
- Changes `<span>` wrappers to `<div>` wrappers for the online and offline variants, matching the existing `<div>` used by the mixed attendance mode

The mixed mode already used a `<div>` wrapper, so the website link aligned correctly there. Online and offline used `<span>`, causing the sibling website link `<template>` content to render inline and drop below baseline.

Relates to #529