### PR TITLE
Soften dark mode text from pure white to off-white

### DIFF
--- a/src/styles/_footer.css
+++ b/src/styles/_footer.css
@@ -2,7 +2,7 @@
   --c-color-focus-ring: currentColor;
 
   background: var(--c-footer-color-bg);
-  color: #fff;
+  color: var(--p-color-grey-200);
   padding: var(--p-space-m-l) 0;
   a {
     color: inherit;

--- a/src/styles/themes/_dark.css
+++ b/src/styles/themes/_dark.css
@@ -1,8 +1,8 @@
 html[data-theme='dark'] {
   --s-color-background: var(--p-color-black);
-  --s-color-on-background: var(--p-color-white);
+  --s-color-on-background: var(--p-color-grey-200);
   --s-color-surface: var(--p-color-grey-900);
-  --s-color-on-surface: var(--p-color-white);
+  --s-color-on-surface: var(--p-color-grey-200);
   --s-color-primary: var(--p-color-purple-500);
   --s-color-on-primary: var(--p-color-white);
 
@@ -10,7 +10,7 @@ html[data-theme='dark'] {
   --s-color-secondary: var(--p-color-cyan);
   --s-color-bg: var(--p-color-grey-900);
   --s-color-bg-muted: var(--p-color-grey-900);
-  --s-color-fg: var(--p-color-white);
+  --s-color-fg: var(--p-color-grey-200);
   --s-color-fg-muted: var(--p-color-grey-400);
   --s-color-border: var(--p-color-grey-800);
 


### PR DESCRIPTION
## Summary

- Changes dark mode body text from pure white (`#ffffff`) to `grey-200` (`rgb(229, 231, 235)`) to reduce eye strain
- Applies the same adjustment to the footer text, which was hardcoded to `#fff`
- Masthead, nav, and other small UI elements retain pure white
- Light mode already uses `grey-700` on white (not pure black), so no change needed there