### PR TITLE
Add aria-describedby to event website links for context

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -111,6 +111,11 @@ const isDedicatedToAccessibility = computed(() => {
 const eventUrl = computed(() => getEventUrl(props.event));
 
 /**
+ * Unique ID for the event heading, used by aria-describedby on the website link.
+ */
+const headingId = computed(() => `event-title-${props.event._id}`);
+
+/**
  * Formats speaker list for display
  * If more than 3 speakers, randomly selects 3 to display and shows count of remaining.
  * This avoids giving preferential visibility to any particular speaker.
@@ -182,7 +187,7 @@ const speakerDisplay = computed(() => {
     itemtype="https://schema.org/Event"
     :data-event-type="event.type"
   >
-    <h3 class="event__title" itemprop="name">
+    <h3 :id="headingId" class="event__title" itemprop="name">
       <a
         v-if="event.type === 'theme' && event.website"
         :href="event.website"
@@ -213,6 +218,7 @@ const speakerDisplay = computed(() => {
       :attendanceMode="event.attendanceMode"
       :location="event.location"
       :website="event.type !== 'theme' ? event.website : undefined"
+      :headingId="headingId"
       v-if="event.type !== 'deadline'"
     />
 

--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -20,11 +20,13 @@ const props = withDefaults(
     attendanceMode?: AttendanceMode;
     location?: string;
     website?: string;
+    headingId?: string;
   }>(),
   {
     attendanceMode: 'none',
     location: 'International',
     website: undefined,
+    headingId: undefined,
   }
 );
 
@@ -99,7 +101,11 @@ const locationIcon = computed(() =>
 
     <template v-if="website">
       <span aria-hidden="true"> · </span>
-      <a :href="website" rel="noopener noreferrer" class="event__website-link"
+      <a
+        :href="website"
+        rel="noopener noreferrer"
+        class="event__website-link"
+        :aria-describedby="headingId"
         >Event website<span class="sr-only"> (opens external site)</span></a
       >
     </template>

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -24,6 +24,7 @@ const { event } = Astro.props;
 
 const isDeadline = event.type === 'deadline';
 const isTheme = event.type === 'theme';
+const headingId = `event-title-${event._id}`;
 const isAllDay = event.day === true;
 const isInternational = !event.timezone;
 
@@ -92,7 +93,7 @@ const displayLocation = event.location || 'International';
       itemtype="https://schema.org/Event"
       data-event-type={event.type}
     >
-      <h3 class="event__title" itemprop="name">
+      <h3 id={headingId} class="event__title" itemprop="name">
         {isTheme && event.website ? (
           <a href={event.website} rel="noopener noreferrer">
             {event.title}
@@ -185,6 +186,7 @@ const displayLocation = event.location || 'International';
                 href={event.website}
                 rel="noopener noreferrer"
                 class="event__website-link"
+                aria-describedby={headingId}
               >
                 Event website<span class="sr-only"> (opens external site)</span>
               </a>
@@ -211,6 +213,7 @@ const displayLocation = event.location || 'International';
                 href={event.website}
                 rel="noopener noreferrer"
                 class="event__website-link"
+                aria-describedby={headingId}
               >
                 Event website<span class="sr-only"> (opens external site)</span>
               </a>


### PR DESCRIPTION
## Summary

- Adds a unique `id` (based on event `_id`) to each event heading (`<h3>`) in `Event.vue` and `StaticEvent.astro`
- Adds `aria-describedby` pointing to that heading on every "Event website" link in `EventDelivery.vue` and `StaticEvent.astro`
- Screen readers will now announce the event title as additional context when the user focuses an "Event website" link, disambiguating otherwise identical link text

### Before
> "Event website (opens external site)" repeated for every event

### After
> "Event website (opens external site), CSUN Assistive Technology Conference 2026"

All 70 tests pass (57 accessibility + 13 event page).