### PR TITLE
Filter third-party popover errors and localhost noise from Sentry

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -2,6 +2,19 @@ import * as Sentry from '@sentry/astro';
 
 Sentry.init({
   dsn: 'https://63a5e1fe7a29dc3df46923bd277aa87e@o4505086842437632.ingest.us.sentry.io/4508463077588992',
+
+  // Discard errors that originate from localhost so that local dev noise
+  // never pollutes the production Sentry project (EVENTUA11Y-S).
+  allowUrls: [/https?:\/\/eventua11y\.com/],
+
+  // Suppress errors thrown internally by the Web Awesome library's wa-popup
+  // component, which calls hidePopover() without first checking whether the
+  // popover is showing (EVENTUA11Y-T, EVENTUA11Y-V).
+  ignoreErrors: [
+    /Failed to execute 'hidePopover' on 'HTMLElement'/,
+    /Failed to execute 'showPopover' on 'HTMLElement'/,
+  ],
+
   beforeSendSpan(span) {
     // Filter out data URI fetches (e.g. inline SVGs) which are in-memory,
     // not real network requests, and trigger false N+1 API call warnings


### PR DESCRIPTION
## Summary

- **Adds `allowUrls`** to restrict Sentry error reporting to `eventua11y.com`, preventing local dev errors from polluting the production project (fixes EVENTUA11Y-S — a `TypeError` for a dynamic import of `aria-query` originating from `localhost:8888`).
- **Adds `ignoreErrors`** for the Web Awesome library's internal `hidePopover()` / `showPopover()` `InvalidStateError`, which is thrown by the `wa-popup` component when it calls `hidePopover()` without first checking whether the popover is visible (fixes EVENTUA11Y-T, EVENTUA11Y-V). This is a [known issue](https://github.com/nicehash/web-awesome/issues?q=hidePopover) in the Web Awesome library and not something we can fix in our code.

## Details

All three recent Sentry alerts are noise rather than actionable bugs:

| Issue | Error | Root cause |
|-------|-------|------------|
| EVENTUA11Y-S | `TypeError: error loading dynamically imported module` | Local dev error (`localhost:8888`) sent to the production Sentry project |
| EVENTUA11Y-T | `InvalidStateError: Failed to execute 'hidePopover'` | Web Awesome `wa-popup` internal bug — calls `hidePopover()` on a popover that isn't showing |
| EVENTUA11Y-V | `InvalidStateError: Failed to execute 'hidePopover'` | Same as above, different stacktrace entry point |