### PR TITLE
Fix trailing space inside event website link in schedule section

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -340,9 +340,13 @@ const jsonLd = {
             </ol>
             {event.website && (
               <p>
-                Refer to the{' '}
-                <a href={event.website} rel="noopener noreferrer">official event website</a>{' '}
-                for the full schedule.
+                {`Refer to the `}
+                <a
+                  href={event.website}
+                  rel="noopener noreferrer"
+                  set:text="official event website"
+                />
+                {` for the full schedule.`}
               </p>
             )}
           </section>


### PR DESCRIPTION
## Summary

- Fixes a trailing space appearing inside the "official event website" link text on event detail pages (e.g. `[official event website ]` instead of `[official event website]`)
- Uses Astro's `set:text` directive to prevent Prettier from introducing whitespace between the link text and closing `</a>` tag