### PR TITLE
Fix event website link dropping to next line for theme days

### DIFF
--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -50,6 +50,7 @@ const locationIcon = computed(() =>
   <div class="event__delivery text-small">
     <div
       v-if="attendanceMode === ATTENDANCE_MODES.ONLINE"
+      class="event__attendance-mode"
       itemprop="eventAttendanceMode"
       content="https://schema.org/OnlineEventAttendanceMode"
     >
@@ -61,6 +62,7 @@ const locationIcon = computed(() =>
 
     <div
       v-else-if="attendanceMode === ATTENDANCE_MODES.OFFLINE"
+      class="event__attendance-mode"
       itemprop="eventAttendanceMode"
       content="https://schema.org/OfflineEventAttendanceMode"
     >
@@ -74,6 +76,7 @@ const locationIcon = computed(() =>
 
     <div
       v-else-if="attendanceMode === ATTENDANCE_MODES.MIXED"
+      class="event__attendance-mode"
       itemprop="eventAttendanceMode"
       content="https://schema.org/MixedEventAttendanceMode"
     >
@@ -90,7 +93,10 @@ const locationIcon = computed(() =>
       </span>
     </div>
 
-    <div v-else-if="attendanceMode === ATTENDANCE_MODES.NONE">
+    <div
+      v-else-if="attendanceMode === ATTENDANCE_MODES.NONE"
+      class="event__attendance-mode"
+    >
       <span class="event__location">
         <wa-icon :name="locationIcon"></wa-icon>
         <span itemprop="location" itemscope itemtype="https://schema.org/Place">

--- a/src/styles/_events.css
+++ b/src/styles/_events.css
@@ -56,7 +56,7 @@
   margin-bottom: 0;
 }
 
-[itemprop='eventAttendanceMode'] {
+.event__attendance-mode {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
@@ -64,11 +64,11 @@
   max-width: 100%; /* Contain within parent width */
 }
 
-[itemprop='eventAttendanceMode'] > * {
+.event__attendance-mode > * {
   flex: 0 0 auto;
 }
 
-[itemprop='eventAttendanceMode'] > span {
+.event__attendance-mode > span {
   display: inline-block; /* Allow text wrapping within spans */
   max-width: 100%; /* Ensure spans don't overflow */
   overflow-wrap: break-word; /* Break long words if needed */


### PR DESCRIPTION
## Summary

- Fixes the "Event website" link dropping onto a new line below the location on theme day event pages (and any event with `attendanceMode: none`)
- The `NONE` attendance mode `<div>` lacked the `itemprop="eventAttendanceMode"` attribute that the CSS relied on to apply `display: inline-flex`, so it stayed block-level
- Adds a `.event__attendance-mode` class to all four attendance mode variants and switches the CSS selectors from `[itemprop='eventAttendanceMode']` to `.event__attendance-mode`

## Before

![Event website link on a separate line below the location](https://github.com/user-attachments/assets/placeholder)

The "Event website" link appears on a new line below "International".

## After

Location and "Event website" link appear inline on the same line, separated by a `·` dot.

## Testing

- All 94 E2E tests pass