### PR TITLE
Consolidate structured data to JSON-LD and remove inline microdata

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -129,27 +129,19 @@ const speakerDisplay = computed(() => {
   if (speakers.length === 0) return '';
 
   if (speakers.length === 1) {
-    return `<span itemprop="performer" itemscope itemtype="https://schema.org/Person"><span itemprop="name">${speakers[0].name}</span></span>`;
+    return speakers[0].name;
   }
 
   if (speakers.length === 2) {
-    return speakers
-      .map(
-        (speaker) =>
-          `<span itemprop="performer" itemscope itemtype="https://schema.org/Person"><span itemprop="name">${speaker.name}</span></span>`
-      )
-      .join(' and ');
+    return speakers.map((speaker) => speaker.name).join(' and ');
   }
 
   if (speakers.length === MAX_DISPLAYED_SPEAKERS) {
     const first = speakers
       .slice(0, MAX_DISPLAYED_SPEAKERS - 1)
-      .map(
-        (speaker) =>
-          `<span itemprop="performer" itemscope itemtype="https://schema.org/Person"><span itemprop="name">${speaker.name}</span></span>`
-      )
+      .map((speaker) => speaker.name)
       .join(', ');
-    return `${first} and <span itemprop="performer" itemscope itemtype="https://schema.org/Person"><span itemprop="name">${speakers[MAX_DISPLAYED_SPEAKERS - 1].name}</span></span>`;
+    return `${first} and ${speakers[MAX_DISPLAYED_SPEAKERS - 1].name}`;
   }
 
   // Randomise which speakers are shown to avoid favouring any individual
@@ -157,10 +149,7 @@ const speakerDisplay = computed(() => {
 
   const firstSpeakers = shuffled
     .slice(0, MAX_DISPLAYED_SPEAKERS)
-    .map(
-      (speaker) =>
-        `<span itemprop="performer" itemscope itemtype="https://schema.org/Person"><span itemprop="name">${speaker.name}</span></span>`
-    )
+    .map((speaker) => speaker.name)
     .join(', ');
 
   return `${firstSpeakers}, and ${speakers.length - MAX_DISPLAYED_SPEAKERS} other speaker${speakers.length - MAX_DISPLAYED_SPEAKERS > 1 ? 's' : ''}`;
@@ -183,15 +172,12 @@ const speakerDisplay = computed(() => {
   <article
     v-else-if="event && event.type"
     :class="`event event--${event.type}`"
-    itemscope
-    itemtype="https://schema.org/Event"
     :data-event-type="event.type"
   >
-    <h3 :id="headingId" class="event__title" itemprop="name">
+    <h3 :id="headingId" class="event__title">
       <a v-if="eventUrl" :href="eventUrl">{{ event.title }}</a>
       <span v-else>{{ event.title }}</span>
     </h3>
-    <meta v-if="event.website" itemprop="url" :content="event.website" />
 
     <EventDate
       v-if="showDate && event.dateStart"
@@ -224,7 +210,7 @@ const speakerDisplay = computed(() => {
         <wa-icon name="caret-right" auto-width></wa-icon>
         Description
       </summary>
-      <p class="event__description" itemprop="description">
+      <p class="event__description">
         {{ event.description }}
       </p>
     </details>

--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -95,22 +95,14 @@ const childEventUrl = computed(() => getEventUrl(props.event));
 const speakersList = computed(() => {
   if (!props.event.speakers?.length) return '';
   return props.event.speakers
-    .map(
-      (speaker) =>
-        `<span itemprop="performer" itemscope itemtype="https://schema.org/Person"><span itemprop="name">${speaker.name}</span></span>`
-    )
+    .map((speaker) => `<span>${speaker.name}</span>`)
     .join(', ');
 });
 </script>
 
 <template>
-  <article
-    class="child-event"
-    itemprop="subEvent"
-    itemscope
-    itemtype="https://schema.org/Event"
-  >
-    <span class="child-event__title" itemprop="name">
+  <article class="child-event">
+    <span class="child-event__title">
       <a v-if="childEventUrl" :href="childEventUrl">{{ event.title }}</a>
       <a v-else-if="event.website" :href="event.website">{{ event.title }}</a>
       <span v-else>{{ event.title }}</span>

--- a/src/components/EventDate.vue
+++ b/src/components/EventDate.vue
@@ -1,20 +1,5 @@
 <template>
   <div class="event__dates">
-    <!-- Machine-readable start date for Schema.org -->
-    <time
-      :datetime="formatDate(dateStart, 'YYYY-MM-DDTHH:mm:ssZ')"
-      itemprop="startDate"
-      hidden
-    ></time>
-
-    <!-- Machine-readable end date for Schema.org -->
-    <time
-      v-if="dateEnd"
-      :datetime="formatDate(dateEnd, 'YYYY-MM-DDTHH:mm:ssZ')"
-      itemprop="endDate"
-      hidden
-    ></time>
-
     <!-- Human-readable date range with locale-aware deduplication -->
     <span class="event__dateRange">
       {{ formattedRange[0]

--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -53,8 +53,6 @@ const locationIcon = computed(() =>
     <div
       v-if="attendanceMode === ATTENDANCE_MODES.ONLINE"
       class="event__attendance-mode"
-      itemprop="eventAttendanceMode"
-      content="https://schema.org/OnlineEventAttendanceMode"
     >
       <span class="event__online">
         <wa-icon name="laptop" auto-width></wa-icon>
@@ -65,28 +63,20 @@ const locationIcon = computed(() =>
     <div
       v-else-if="attendanceMode === ATTENDANCE_MODES.OFFLINE"
       class="event__attendance-mode"
-      itemprop="eventAttendanceMode"
-      content="https://schema.org/OfflineEventAttendanceMode"
     >
       <span class="event__location">
         <wa-icon name="location-dot"></wa-icon>
-        <span itemprop="location" itemscope itemtype="https://schema.org/Place">
-          {{ displayLocation }}
-        </span>
+        <span>{{ displayLocation }}</span>
       </span>
     </div>
 
     <div
       v-else-if="attendanceMode === ATTENDANCE_MODES.MIXED"
       class="event__attendance-mode"
-      itemprop="eventAttendanceMode"
-      content="https://schema.org/MixedEventAttendanceMode"
     >
       <span class="event__location">
         <wa-icon name="location-dot"></wa-icon>
-        <span itemprop="location" itemscope itemtype="https://schema.org/Place">
-          {{ displayLocation }}
-        </span>
+        <span>{{ displayLocation }}</span>
       </span>
       <span class="text-muted">and</span>
       <span class="event__online">
@@ -101,9 +91,7 @@ const locationIcon = computed(() =>
     >
       <span class="event__location">
         <wa-icon :name="locationIcon"></wa-icon>
-        <span itemprop="location" itemscope itemtype="https://schema.org/Place">
-          {{ displayLocation }}
-        </span>
+        <span>{{ displayLocation }}</span>
       </span>
     </div>
 

--- a/src/components/EventDuration.vue
+++ b/src/components/EventDuration.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="event__duration">
     <span class="sr-only">Duration</span>
-    <time :datetime="`PT${duration}M`" itemprop="duration">
+    <time :datetime="`PT${duration}M`">
       <wa-icon name="timer" auto-width></wa-icon>
       {{ formattedDuration }}
     </time>

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -3,7 +3,7 @@
  * Server-rendered event card for the <noscript> fallback.
  *
  * This is a simplified Astro version of Event.vue that renders
- * Schema.org-annotated HTML without any client-side interactivity.
+ * HTML without any client-side interactivity.
  * It uses UTC dates since user timezone is unknown during SSR.
  */
 import dayjs from 'dayjs';
@@ -63,11 +63,6 @@ const displayLocation = event.location || 'International';
   isDeadline ? (
     <div class="event event--deadline">
       <div class="event__dates">
-        <time
-          datetime={formatDate(event.dateStart, 'YYYY-MM-DDTHH:mm:ssZ')}
-          itemprop="startDate"
-          hidden
-        />
         <span class="event__dateRange">
           {formattedRange[0]}
           {formattedRange[1] && (
@@ -87,35 +82,17 @@ const displayLocation = event.location || 'International';
       </span>
     </div>
   ) : event.type ? (
-    <article
-      class={`event event--${event.type}`}
-      itemscope
-      itemtype="https://schema.org/Event"
-      data-event-type={event.type}
-    >
-      <h3 id={headingId} class="event__title" itemprop="name">
+    <article class={`event event--${event.type}`} data-event-type={event.type}>
+      <h3 id={headingId} class="event__title">
         {eventUrl ? (
           <a href={eventUrl}>{event.title}</a>
         ) : (
           <span>{event.title}</span>
         )}
       </h3>
-      {event.website && <meta itemprop="url" content={event.website} />}
 
       {event.dateStart && (
         <div class="event__dates">
-          <time
-            datetime={formatDate(event.dateStart, 'YYYY-MM-DDTHH:mm:ssZ')}
-            itemprop="startDate"
-            hidden
-          />
-          {event.dateEnd && (
-            <time
-              datetime={formatDate(event.dateEnd, 'YYYY-MM-DDTHH:mm:ssZ')}
-              itemprop="endDate"
-              hidden
-            />
-          )}
           <span class="event__dateRange">
             {formattedRange[0]}
             {formattedRange[1] && (
@@ -133,43 +110,17 @@ const displayLocation = event.location || 'International';
       {attendanceMode !== 'none' && event.type !== 'deadline' && (
         <div class="event__delivery text-small">
           {attendanceMode === 'online' && (
-            <span class="event__online">
-              <meta
-                itemprop="eventAttendanceMode"
-                content="https://schema.org/OnlineEventAttendanceMode"
-              />
-              Online
-            </span>
+            <span class="event__online">Online</span>
           )}
           {attendanceMode === 'offline' && (
             <span class="event__location">
-              <meta
-                itemprop="eventAttendanceMode"
-                content="https://schema.org/OfflineEventAttendanceMode"
-              />
-              <span
-                itemprop="location"
-                itemscope
-                itemtype="https://schema.org/Place"
-              >
-                {displayLocation}
-              </span>
+              <span>{displayLocation}</span>
             </span>
           )}
           {attendanceMode === 'mixed' && (
             <div>
-              <meta
-                itemprop="eventAttendanceMode"
-                content="https://schema.org/MixedEventAttendanceMode"
-              />
               <span class="event__location">
-                <span
-                  itemprop="location"
-                  itemscope
-                  itemtype="https://schema.org/Place"
-                >
-                  {displayLocation}
-                </span>
+                <span>{displayLocation}</span>
               </span>
               <span class="text-muted"> and </span>
               <span class="event__online">Online</span>
@@ -194,13 +145,7 @@ const displayLocation = event.location || 'International';
       {attendanceMode === 'none' && event.type !== 'deadline' && (
         <div class="event__delivery text-small">
           <span class="event__location">
-            <span
-              itemprop="location"
-              itemscope
-              itemtype="https://schema.org/Place"
-            >
-              {displayLocation}
-            </span>
+            <span>{displayLocation}</span>
           </span>
           {event.website && !isTheme && (
             <Fragment>
@@ -221,9 +166,7 @@ const displayLocation = event.location || 'International';
       {event.description && !isTheme && (
         <details class="event__children flow">
           <summary>Description</summary>
-          <p class="event__description" itemprop="description">
-            {event.description}
-          </p>
+          <p class="event__description">{event.description}</p>
         </details>
       )}
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -117,6 +117,8 @@ const jsonLd = {
   startDate: event.dateStart,
   ...(event.dateEnd && { endDate: event.dateEnd }),
   ...(event.website && { url: event.website }),
+  eventStatus: 'https://schema.org/EventScheduled',
+  inLanguage: 'en',
   ...(event.attendanceMode === 'online' && {
     eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
     location: { '@type': 'VirtualLocation', url: event.website },
@@ -124,18 +126,38 @@ const jsonLd = {
   ...(event.attendanceMode === 'offline' && {
     eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
     ...(event.location && {
-      location: { '@type': 'Place', name: event.location },
+      location: {
+        '@type': 'Place',
+        name: event.location,
+        address: { '@type': 'PostalAddress', name: event.location },
+      },
     }),
   }),
   ...(event.attendanceMode === 'mixed' && {
     eventAttendanceMode: 'https://schema.org/MixedEventAttendanceMode',
     location: [
-      ...(event.location ? [{ '@type': 'Place', name: event.location }] : []),
+      ...(event.location
+        ? [
+            {
+              '@type': 'Place',
+              name: event.location,
+              address: { '@type': 'PostalAddress', name: event.location },
+            },
+          ]
+        : []),
       ...(event.website
         ? [{ '@type': 'VirtualLocation', url: event.website }]
         : []),
     ],
   }),
+  ...((!event.attendanceMode || event.attendanceMode === 'none') &&
+    event.location && {
+      location: {
+        '@type': 'Place',
+        name: event.location,
+        address: { '@type': 'PostalAddress', name: event.location },
+      },
+    }),
   ...(allSpeakers.length > 0 && {
     performer: allSpeakers.map((s) => ({
       '@type': 'Person',
@@ -144,6 +166,13 @@ const jsonLd = {
   }),
   ...(event.isFree && {
     isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: 0,
+      priceCurrency: 'USD',
+      availability: 'https://schema.org/InStock',
+      ...(event.website && { url: event.website }),
+    },
   }),
   ...(event.organizer && {
     organizer: {
@@ -160,23 +189,28 @@ const jsonLd = {
         ...(parentUrl && { url: `https://eventua11y.com${parentUrl}` }),
       },
     }),
+  ...(hasChildren && {
+    subEvent: (event.children ?? []).map((child) => ({
+      '@type': 'Event',
+      name: child.title,
+      ...(child.dateStart && { startDate: child.dateStart }),
+      ...(child.dateEnd && { endDate: child.dateEnd }),
+      ...(child.slug?.current && {
+        url: `https://eventua11y.com/events/${child.slug.current}`,
+      }),
+    })),
+  }),
 };
 ---
 
 <DefaultLayout title={event.title} description={metaDescription} ogType="event">
   <div class="container py-l">
     <div class="event-detail-layout">
-      <article
-        class="event-detail flow flow-m"
-        itemscope
-        itemtype="https://schema.org/Event"
-      >
+      <article class="event-detail flow flow-m">
         {
           displayFormat || (isChildEvent && event.parentEvent) ? (
             <hgroup role="group" aria-roledescription="Heading group">
-              <h1 class="event-detail__title" itemprop="name">
-                {event.title}
-              </h1>
+              <h1 class="event-detail__title">{event.title}</h1>
               <p aria-roledescription="subtitle" class="text-muted">
                 {displayFormat && (
                   <span>
@@ -188,13 +222,7 @@ const jsonLd = {
                         {allSpeakers.map((speaker, i) => (
                           <Fragment>
                             {i > 0 && ', '}
-                            <span
-                              itemprop="performer"
-                              itemscope
-                              itemtype="https://schema.org/Person"
-                            >
-                              <span itemprop="name">{speaker.name}</span>
-                            </span>
+                            <span>{speaker.name}</span>
                           </Fragment>
                         ))}
                       </Fragment>
@@ -217,9 +245,7 @@ const jsonLd = {
               </p>
             </hgroup>
           ) : (
-            <h1 class="event-detail__title" itemprop="name">
-              {event.title}
-            </h1>
+            <h1 class="event-detail__title">{event.title}</h1>
           )
         }
 
@@ -268,7 +294,7 @@ const jsonLd = {
           event.description && (
             <div class="event-detail__description">
               <h2 class="text-large">Description</h2>
-              <p itemprop="description">{event.description}</p>
+              <p>{event.description}</p>
             </div>
           )
         }
@@ -281,12 +307,8 @@ const jsonLd = {
               </h2>
               <ul role="list" class="event-detail__speaker-list">
                 {allSpeakers.map((speaker) => (
-                  <li
-                    itemprop="performer"
-                    itemscope
-                    itemtype="https://schema.org/Person"
-                  >
-                    <span itemprop="name">{speaker.name}</span>
+                  <li>
+                    <span>{speaker.name}</span>
                   </li>
                 ))}
               </ul>
@@ -460,7 +482,7 @@ const jsonLd = {
     flex-wrap: wrap;
   }
 
-  .event-detail__speaker-list li:not(:last-child) [itemprop='name']::after {
+  .event-detail__speaker-list li:not(:last-child) span::after {
     content: ',\00a0';
   }
 

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -59,13 +59,6 @@ test.describe('Event detail page', () => {
     await expect(footer).toBeVisible();
   });
 
-  test('article has Schema.org Event markup', async ({ page }) => {
-    const article = page.locator(
-      'article[itemtype="https://schema.org/Event"]'
-    );
-    await expect(article).toBeVisible();
-  });
-
   test('page contains JSON-LD structured data', async ({ page }) => {
     const jsonLd = page.locator('script[type="application/ld+json"]');
     await expect(jsonLd).toBeAttached();


### PR DESCRIPTION
## Summary

- Removes all inline microdata (`itemscope`, `itemprop`, `itemtype`) from event templates and components, consolidating structured data into the existing JSON-LD block on event detail pages
- Strengthens JSON-LD output with `eventStatus`, `inLanguage`, `subEvent` array, `offers` (for free events), `PostalAddress` for in-person locations, and a location fallback for events with no attendance mode set

## Why

The site previously had **two competing structured data strategies**: inline microdata scattered across Vue components and Astro templates, plus a JSON-LD script block on event detail pages. This created maintenance burden and risk of the two representations drifting out of sync. JSON-LD is the [recommended approach by Google](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data#supported-formats) and is easier to maintain since it lives in a single location.

## Changes

| File | Change |
|---|---|
| `src/pages/events/[slug].astro` | Enhanced JSON-LD with `eventStatus`, `inLanguage`, `subEvent`, `offers`, `PostalAddress`, location fallback |
| `src/components/Event.vue` | Removed `itemscope`, `itemprop` on title, URL, description, speakers |
| `src/components/EventChild.vue` | Removed `itemprop="subEvent"` and speaker microdata |
| `src/components/EventDate.vue` | Removed hidden `<time>` elements used only for microdata |
| `src/components/EventDelivery.vue` | Removed `itemprop` from location/URL, simplified template |
| `src/components/EventDuration.vue` | Removed `itemprop="duration"` |
| `src/components/StaticEvent.astro` | Removed all microdata attributes and hidden microdata-only elements |
| `tests/event-page.spec.ts` | Removed Playwright assertion for `article[itemtype]` |