### PR TITLE
Add caching to event detail pages

### DIFF
--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -174,13 +174,30 @@ export async function getEvents(): Promise<{
 // ── Single event query ─────────────────────────────────────────────────
 
 /**
+ * In-memory cache for single event lookups, keyed by slug.
+ * Mirrors the 5-minute TTL caching strategy used by the
+ * get-events and get-books edge functions to reduce Sanity API calls.
+ */
+const eventCache: Record<string, { data: Event | null; timestamp: number }> =
+  {};
+const EVENT_CACHE_TTL = 300000; // 5 minutes in milliseconds
+
+/**
  * Fetches a single event by its slug, including resolved speakers
  * and child events. Returns null if no matching event is found.
+ *
+ * Results are cached in memory for 5 minutes per slug to reduce
+ * Sanity API calls across requests within the same function instance.
  *
  * Child events (those with a parent reference) inherit attendanceMode
  * and location from their parent when their own values are not set.
  */
 export async function getEventBySlug(slug: string): Promise<Event | null> {
+  const cached = eventCache[slug];
+  if (cached && Date.now() - cached.timestamp < EVENT_CACHE_TTL) {
+    return cached.data;
+  }
+
   const client = getSanityClient();
 
   const event: RawEvent | null = await client.fetch(
@@ -202,13 +219,19 @@ export async function getEventBySlug(slug: string): Promise<Event | null> {
     { slug }
   );
 
-  if (!event) return null;
+  if (!event) {
+    eventCache[slug] = { data: null, timestamp: Date.now() };
+    return null;
+  }
 
-  return {
+  const result = {
     ...event,
     children:
       event.children && event.children.length > 0 ? event.children : undefined,
   } as Event;
+
+  eventCache[slug] = { data: result, timestamp: Date.now() };
+  return result;
 }
 
 // ── Book queries ───────────────────────────────────────────────────────

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -30,6 +30,13 @@ if (!event) {
   return Astro.redirect('/404');
 }
 
+// Cache the response to reduce Sanity API calls, matching the
+// strategy used by the get-events edge function.
+Astro.response.headers.set(
+  'Cache-Control',
+  'private, max-age=300, stale-while-revalidate=60'
+);
+
 // Build meta description from event data
 const metaDescription = event.description
   ? event.description.slice(0, 160) +


### PR DESCRIPTION
## Summary

- Add in-memory cache (5-minute TTL) to `getEventBySlug()`, matching the caching strategy already used by the `get-events` and `get-books` edge functions
- Set `Cache-Control: private, max-age=300, stale-while-revalidate=60` on event detail page responses for browser-level caching
- Both null results (404s) and successful lookups are cached to avoid repeated Sanity queries for the same slug