### PR TITLE
Add cache headers to SSR pages and static assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,18 @@
 # Each function exports its own config with the path, so no explicit
 # [[edge_functions]] entries are needed here.
 
+# Immutable caching for hashed Astro assets (JS, CSS)
+[[headers]]
+  for = "/_astro/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Long cache for favicon assets
+[[headers]]
+  for = "/favicon/*"
+  [headers.values]
+    Cache-Control = "public, max-age=86400"
+
 # Redirect /events to the homepage at the CDN edge,
 # avoiding a serverless function invocation.
 [[redirects]]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,13 @@ import FilterBarPlaceholder from '../components/FilterBarPlaceholder.astro';
 
 // Disable prerendering to enable SSR
 export const prerender = false;
+
+// Cache the response to reduce origin hits, matching the
+// strategy used by the get-events edge function.
+Astro.response.headers.set(
+  'Cache-Control',
+  'private, max-age=300, stale-while-revalidate=60'
+);
 ---
 
 <DefaultLayout>

--- a/src/pages/past-events.astro
+++ b/src/pages/past-events.astro
@@ -6,6 +6,13 @@ import StaticEventList from '../components/StaticEventList.astro';
 
 // Disable prerendering to enable SSR
 export const prerender = false;
+
+// Cache the response to reduce origin hits, matching the
+// strategy used by the get-events edge function.
+Astro.response.headers.set(
+  'Cache-Control',
+  'private, max-age=300, stale-while-revalidate=60'
+);
 ---
 
 <DefaultLayout title="Past accessibility events">


### PR DESCRIPTION
## Summary

Two caching improvements from Tier 2 of #594.

- **SSR page cache headers** — Add `Cache-Control: private, max-age=300, stale-while-revalidate=60` to the homepage and past-events page, matching the strategy already used on event detail pages. Browser caches the page for 5 minutes with a 1-minute stale grace period. (closes #599)
- **Netlify static asset headers** — Immutable caching for hashed Astro assets (`/_astro/*`) and long cache for favicons (`/favicon/*`) in `netlify.toml`. (closes #598)

## Testing

- Build succeeds locally
- No logic changes — only HTTP headers added