### PR TITLE
Defer non-critical Vue component hydration

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -269,7 +269,7 @@ const jsonLd = {
         />
 
         <EventDelivery
-          client:load
+          client:idle
           attendanceMode={event.attendanceMode as any}
           location={event.location}
           website={event.website}
@@ -345,7 +345,11 @@ const jsonLd = {
                 {event.children!.map((child) => (
                   <li>
                     <wa-card appearance="outlined">
-                      <EventChild client:load event={child} showEnded={true} />
+                      <EventChild
+                        client:visible
+                        event={child}
+                        showEnded={true}
+                      />
                     </wa-card>
                   </li>
                 ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,7 @@ Astro.response.headers.set(
     <MonthNav
       id="month-nav"
       class="mb-l"
-      client:load
+      client:idle
       contentRegion="#events"
       showTodayLink={true}
     />

--- a/src/pages/past-events.astro
+++ b/src/pages/past-events.astro
@@ -31,7 +31,7 @@ Astro.response.headers.set(
         <StaticEventList type="past" />
       </noscript>
     </div>
-    <MonthNav id="month-nav" class="mb-l" client:load contentRegion="#events" />
+    <MonthNav id="month-nav" class="mb-l" client:idle contentRegion="#events" />
   </div>
   <!-- End container -->
 </DefaultLayout>


### PR DESCRIPTION
## Summary

Defer hydration of three Vue components that don't need to load eagerly, reducing main-thread work at page load and improving Time to Interactive. (closes #601, part of #594)

| Component | Page | Before | After | Reason |
|---|---|---|---|---|
| MonthNav | homepage, past-events | `client:load` | `client:idle` | Secondary sidebar nav — defers until main thread is free |
| EventDelivery | event detail | `client:load` | `client:idle` | Purely presentational (attendance mode, location) |
| EventChild | event detail (loop) | `client:load` | `client:visible` | Below the fold in child events list — defers until user scrolls to it |

## What to test on the deploy preview

1. **Homepage / past-events** — MonthNav sidebar should still appear and update correctly when scrolling through events. It uses a MutationObserver on the event list DOM, so it needs to mount eventually but not immediately.
2. **Event detail pages with child events** (e.g. a conference with sessions) — child events should render when scrolled into view. Progress indicators should show correct values when they appear.
3. **Event detail pages** — attendance mode and location info should still display correctly.

## Impact on progress indicators

None. Progress timers in EventChild start when the component mounts (on scroll into view with `client:visible`). Since progress is calculated from `dayjs()` at mount time, the bar shows the correct value immediately.