### PR TITLE
Restore <time> elements for event dates

### DIFF
--- a/src/components/EventDate.vue
+++ b/src/components/EventDate.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="event__dates">
-    <!-- Human-readable date range with locale-aware deduplication -->
+    <!-- Human-readable date range with machine-readable <time> elements -->
     <span class="event__dateRange">
-      {{ formattedRange[0]
-      }}<template v-if="formattedRange[1]"
+      <time :datetime="machineStart">{{ formattedRange[0] }}</time
+      ><template v-if="formattedRange[1]"
         ><span aria-hidden="true"> &ndash; </span><span class="sr-only">to</span
-        >{{ formattedRange[1] }}</template
+        ><time :datetime="machineEnd">{{ formattedRange[1] }}</time></template
       ><template v-if="!isInternational"
         >{{ ' '
         }}<abbr :title="getFullTimezoneName(currentTimezone) || undefined">{{
@@ -157,4 +157,24 @@ const currentTimezone = computed(() => {
  * @returns {boolean} True if the event is international
  */
 const isInternational = computed(() => !props.timezone);
+
+/** Whether the event uses date-only display (no times shown) */
+const isDateOnly = computed(
+  () => props.day || props.type === 'theme' || props.isDeadline
+);
+
+/** Machine-readable datetime format for the <time> element */
+const machineFormat = computed(() =>
+  isDateOnly.value ? 'YYYY-MM-DD' : 'YYYY-MM-DDTHH:mm:ssZ'
+);
+
+/** Machine-readable start date for the start <time> element */
+const machineStart = computed(() =>
+  formatDate(props.dateStart, machineFormat.value)
+);
+
+/** Machine-readable end date for the end <time> element */
+const machineEnd = computed(() =>
+  props.dateEnd ? formatDate(props.dateEnd, machineFormat.value) : undefined
+);
 </script>

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -54,6 +54,14 @@ const formattedRange = formatDateRange({
 // Internal event page URL (if slug exists)
 const eventUrl = getEventUrl(event);
 
+// Machine-readable datetime values for <time> elements
+const isDateOnly = isAllDay || isTheme || isDeadline;
+const machineFormat = isDateOnly ? 'YYYY-MM-DD' : 'YYYY-MM-DDTHH:mm:ssZ';
+const machineStart = formatDate(event.dateStart, machineFormat);
+const machineEnd = event.dateEnd
+  ? formatDate(event.dateEnd, machineFormat)
+  : undefined;
+
 // Attendance mode display
 const attendanceMode = event.attendanceMode || 'none';
 const displayLocation = event.location || 'International';
@@ -64,12 +72,12 @@ const displayLocation = event.location || 'International';
     <div class="event event--deadline">
       <div class="event__dates">
         <span class="event__dateRange">
-          {formattedRange[0]}
-          {formattedRange[1] && (
+          <time datetime={machineStart}>{formattedRange[0]}</time>
+          {formattedRange[1] && machineEnd && (
             <>
               <span aria-hidden="true"> &ndash; </span>
               <span class="sr-only">to</span>
-              {formattedRange[1]}
+              <time datetime={machineEnd}>{formattedRange[1]}</time>
             </>
           )}
           {!isInternational && ' UTC'}{' '}
@@ -94,12 +102,12 @@ const displayLocation = event.location || 'International';
       {event.dateStart && (
         <div class="event__dates">
           <span class="event__dateRange">
-            {formattedRange[0]}
-            {formattedRange[1] && (
+            <time datetime={machineStart}>{formattedRange[0]}</time>
+            {formattedRange[1] && machineEnd && (
               <>
                 <span aria-hidden="true"> &ndash; </span>
                 <span class="sr-only">to</span>
-                {formattedRange[1]}
+                <time datetime={machineEnd}>{formattedRange[1]}</time>
               </>
             )}
             {!isInternational && ' UTC'}


### PR DESCRIPTION
## Summary

- Wraps visible event date text in `<time datetime="...">` elements in both `EventDate.vue` and `StaticEvent.astro`
- Uses `YYYY-MM-DD` for date-only events and full ISO 8601 for timed events
- The `<time>` elements were accidentally removed in ca1baba (#589) along with the inline microdata they carried, but they serve an independent semantic purpose for assistive technologies and machine readability
- Also fixes the "limits past events to the last 12 months" E2E test, which relies on `[datetime]` attributes within event cards

Fixes #617