### PR TITLE
Enable Sentry performance monitoring for Core Web Vitals

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -7,6 +7,9 @@ Sentry.init({
   // never pollutes the production Sentry project (EVENTUA11Y-S).
   allowUrls: [/https?:\/\/eventua11y\.com/],
 
+  // Sample 10% of transactions for performance monitoring (Core Web Vitals).
+  tracesSampleRate: 0.1,
+
   // Suppress errors thrown internally by the Web Awesome library's wa-popup
   // component, which calls hidePopover() without first checking whether the
   // popover is showing (EVENTUA11Y-T, EVENTUA11Y-V).


### PR DESCRIPTION
## Summary

- Adds `tracesSampleRate: 0.1` to the Sentry client config to enable performance monitoring, collecting Core Web Vitals (LCP, CLS, INP) from 10% of real user sessions.

Closes #603