### PR TITLE
Add dynamic XML sitemap for SEO

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
-# Example: Allow all bots to scan and index your site.
-# Full syntax: https://developers.google.com/search/docs/advanced/robots/create-robots-txt
+# https://developers.google.com/search/docs/advanced/robots/create-robots-txt
 User-agent: *
 Allow: /
+
+Sitemap: https://eventua11y.com/sitemap.xml

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,132 @@
+/**
+ * Dynamic XML sitemap endpoint.
+ *
+ * Generates a sitemap following Google's best practices:
+ * - Uses the sitemap protocol 0.9 namespace
+ * - Includes <lastmod> dates from Sanity _updatedAt fields
+ * - Excludes error pages (404) and non-canonical routes
+ * - Serves correct Content-Type (application/xml)
+ * - Caches responses to reduce Sanity API calls
+ *
+ * Because the site runs in SSR mode with dynamic /events/[slug] routes,
+ * we query Sanity at request time to enumerate all published event slugs
+ * rather than relying on static-only sitemap generators.
+ *
+ * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap
+ * @see https://www.sitemaps.org/protocol.html
+ */
+
+import type { APIRoute } from 'astro';
+import { createClient } from '@sanity/client';
+
+export const prerender = false;
+
+interface SitemapEvent {
+  slug: string;
+  _updatedAt: string;
+}
+
+/**
+ * Fetches all published event slugs and their last-modified dates from Sanity.
+ * Only includes events that have a slug (required to generate a URL).
+ */
+async function getEventSlugs(): Promise<SitemapEvent[]> {
+  const client = createClient({
+    projectId: import.meta.env.SANITY_PROJECT,
+    dataset: import.meta.env.SANITY_DATASET,
+    apiVersion: import.meta.env.SANITY_API_VERSION || '2021-03-25',
+    useCdn: true, // CDN is fine for sitemap reads
+  });
+
+  return client.fetch<SitemapEvent[]>(`
+    *[_type == "event" && defined(slug.current) && !(_id in path("drafts.**"))] {
+      "slug": slug.current,
+      _updatedAt
+    } | order(_updatedAt desc)
+  `);
+}
+
+/**
+ * Formats an ISO date string to the W3C Datetime format used in sitemaps.
+ * Falls back to the current date if the input is invalid.
+ */
+function toW3CDate(isoDate?: string): string {
+  if (!isoDate) return new Date().toISOString().split('T')[0];
+  const date = new Date(isoDate);
+  if (isNaN(date.getTime())) return new Date().toISOString().split('T')[0];
+  return date.toISOString().split('T')[0];
+}
+
+export const GET: APIRoute = async () => {
+  const site = 'https://eventua11y.com';
+  const today = new Date().toISOString().split('T')[0];
+
+  // Fetch all event slugs from Sanity
+  let events: SitemapEvent[] = [];
+  try {
+    events = await getEventSlugs();
+  } catch {
+    // If Sanity is unreachable, generate sitemap with static pages only.
+    // This ensures crawlers still get a valid response.
+  }
+
+  // Static pages with manually assigned priorities.
+  // Priorities are relative hints to search engines about page importance
+  // within this site, not absolute rankings.
+  const staticPages = [
+    { loc: '/', changefreq: 'daily', priority: '1.0', lastmod: today },
+    {
+      loc: '/past-events',
+      changefreq: 'daily',
+      priority: '0.7',
+      lastmod: today,
+    },
+    {
+      loc: '/accessibility',
+      changefreq: 'monthly',
+      priority: '0.5',
+      lastmod: today,
+    },
+    {
+      loc: '/curation-policy',
+      changefreq: 'monthly',
+      priority: '0.5',
+      lastmod: today,
+    },
+  ];
+
+  const urlEntries = staticPages
+    .map(
+      (page) => `  <url>
+    <loc>${site}${page.loc}</loc>
+    <lastmod>${page.lastmod}</lastmod>
+    <changefreq>${page.changefreq}</changefreq>
+    <priority>${page.priority}</priority>
+  </url>`
+    )
+    .concat(
+      events.map(
+        (event) => `  <url>
+    <loc>${site}/events/${event.slug}</loc>
+    <lastmod>${toW3CDate(event._updatedAt)}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>`
+      )
+    )
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urlEntries}
+</urlset>`;
+
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=600',
+      'X-Robots-Tag': 'noindex',
+    },
+  });
+};


### PR DESCRIPTION
## Summary

- Adds a dynamic `/sitemap.xml` SSR endpoint that queries Sanity CMS at request time for all published event slugs, ensuring search engines can discover every event detail page
- Includes all static pages (`/`, `/past-events`, `/accessibility`, `/curation-policy`) with appropriate `<priority>` and `<changefreq>` hints
- Uses Sanity `_updatedAt` timestamps for accurate `<lastmod>` dates on event URLs
- Updates `robots.txt` with a `Sitemap:` directive so crawlers find the sitemap automatically

## Why not `@astrojs/sitemap`?

The site runs in SSR mode (`output: 'server'`). The official Astro sitemap integration only discovers statically prerendered pages — it cannot enumerate the dynamic `/events/[slug]` routes that are resolved at request time via Sanity. A custom endpoint is required.

## Design decisions

- **1-hour cache** (`Cache-Control: public, max-age=3600`) reduces Sanity API calls while keeping the sitemap reasonably fresh
- **Graceful degradation**: if Sanity is unreachable, the endpoint still returns a valid sitemap with static pages only
- **`X-Robots-Tag: noindex`** prevents the sitemap itself from appearing in search results (per Google's recommendation)
- **W3C Datetime format** for `<lastmod>` values (YYYY-MM-DD), as required by the sitemaps protocol