### PR TITLE
Use link color for progress indicator to improve contrast

### DIFF
--- a/src/components/EventProgress.vue
+++ b/src/components/EventProgress.vue
@@ -130,7 +130,7 @@ const accessibleLabel = computed(() => `${progress.value}% complete`);
 
 .event__progress-bar {
   --track-height: 0.35rem;
-  --indicator-color: var(--c-color-link);
+  --indicator-color: var(--c-progress-color-indicator);
   --track-color: var(--wa-color-neutral-fill-normal);
   width: 4rem;
   border-radius: var(--wa-border-radius-pill);
@@ -139,7 +139,7 @@ const accessibleLabel = computed(() => `${progress.value}% complete`);
 
 @keyframes pulse {
   0% {
-    box-shadow: 0 0 0 0 var(--c-color-link);
+    box-shadow: 0 0 0 0 var(--c-progress-color-indicator);
   }
   70% {
     box-shadow: 0 0 0 0.5rem transparent;

--- a/src/styles/themes/_dark.css
+++ b/src/styles/themes/_dark.css
@@ -48,6 +48,9 @@ html[data-theme='dark'] {
   --c-footer-color-link-hover: var(--s-color-secondary);
   --c-footer-color-fg-muted: var(--p-color-grey-400);
 
+  /* Progress */
+  --c-progress-color-indicator: var(--p-color-purple-100);
+
   /* Page header */
   /* --page-header-color-bg: var(--color-primary);
   --page-header-color-fg: var(--color-fg);

--- a/src/styles/themes/_light.css
+++ b/src/styles/themes/_light.css
@@ -44,6 +44,9 @@
   --c-footer-color-link-hover: var(--s-color-secondary);
   --c-footer-color-fg-muted: var(--p-color-grey-400);
 
+  /* Progress */
+  --c-progress-color-indicator: var(--p-color-purple-600);
+
   /* Panel */
   --c-panel-color-bg: var(--s-color-surface);
 


### PR DESCRIPTION
## Summary

- Replaces Web Awesome library tokens (`--wa-color-brand-fill-loud`) with the project's `--c-color-link` token for the progress indicator color, improving contrast between the indicator and track in both light and dark modes.
- Also updates the pulse animation `box-shadow` to match.

Closes #633