### PR TITLE
Add countdown and progress indicators to event detail pages

### DIFF
--- a/src/components/EventDateWithTimezone.vue
+++ b/src/components/EventDateWithTimezone.vue
@@ -6,6 +6,8 @@
       :timezone="timezone"
       :day="day"
       :type="type"
+      :showCountdown="showCountdown"
+      :showEnded="showEnded"
     />
     <!-- <TimezoneSelector size="small" /> -->
   </div>
@@ -22,11 +24,15 @@ withDefaults(
     timezone?: string;
     day?: boolean;
     type?: string;
+    showCountdown?: boolean;
+    showEnded?: boolean;
   }>(),
   {
     timezone: '',
     day: false,
     type: 'event',
+    showCountdown: false,
+    showEnded: false,
   }
 );
 </script>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -266,6 +266,8 @@ const jsonLd = {
           timezone={event.timezone}
           day={event.day}
           type={event.type}
+          showCountdown={true}
+          showEnded={true}
         />
 
         <EventDelivery


### PR DESCRIPTION
## Summary

- Forwards `showCountdown` and `showEnded` props through `EventDateWithTimezone` to `EventDate`/`EventProgress`, enabling live "Starts in" countdowns, progress bars, and "Ended" indicators on individual event pages — matching the behaviour already present on event cards in the Today section.

## Changes

- **`EventDateWithTimezone.vue`**: Added optional `showCountdown` and `showEnded` props (default `false`) and forwarded them to the inner `EventDate` component.
- **`[slug].astro`**: Set `showCountdown={true}` and `showEnded={true}` on the `EventDateWithTimezone` instance.

No other consumers of `EventDateWithTimezone` exist, so the defaults preserve existing behaviour.