### PR TITLE
Display 'Today' instead of day name when a date is today

### DIFF
--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 /** Non-breaking space used between time digits and AM/PM */
 const nbsp = '\u00A0';
@@ -11,6 +13,7 @@ import {
   getStartDateFormat,
   getEndDateFormat,
   isSameDay,
+  isToday,
   formatEventDate,
   formatDateRange,
   getYearMonth,
@@ -171,6 +174,46 @@ describe('isSameDay', () => {
         useLocalTimezone: true,
         userTimezone: 'Europe/Paris',
       })
+    ).toBe(true);
+  });
+});
+
+describe('isToday', () => {
+  it('returns true when the date is today in UTC', () => {
+    const now = dayjs.utc('2026-03-09T12:00:00Z');
+    expect(
+      isToday('2026-03-09T14:00:00Z', { timezone: 'UTC' }, now.tz('UTC'))
+    ).toBe(true);
+  });
+
+  it('returns false when the date is not today in UTC', () => {
+    const now = dayjs.utc('2026-03-09T12:00:00Z');
+    expect(
+      isToday('2026-03-10T14:00:00Z', { timezone: 'UTC' }, now.tz('UTC'))
+    ).toBe(false);
+  });
+
+  it('respects timezone when determining today', () => {
+    // 2026-03-09T23:00:00Z is Mar 10 in UTC+2 (Helsinki)
+    const now = dayjs.utc('2026-03-10T01:00:00Z').tz('Europe/Helsinki');
+    expect(
+      isToday('2026-03-09T23:00:00Z', { timezone: 'Europe/Helsinki' }, now)
+    ).toBe(true); // Both are Mar 10 in Helsinki
+  });
+
+  it('uses user timezone when useLocalTimezone is true', () => {
+    // 2026-03-09T23:00:00Z is still Mar 9 in UTC, but Mar 10 in Helsinki
+    const now = dayjs.utc('2026-03-10T01:00:00Z').tz('Europe/Helsinki');
+    expect(
+      isToday(
+        '2026-03-09T23:00:00Z',
+        {
+          timezone: 'UTC',
+          useLocalTimezone: true,
+          userTimezone: 'Europe/Helsinki',
+        },
+        now
+      )
     ).toBe(true);
   });
 });
@@ -466,12 +509,15 @@ describe('formatDateRange', () => {
   describe('timezone handling', () => {
     it('converts to event timezone', () => {
       // UTC 23:00 Mar 8 = EDT 19:00 Mar 8; UTC 03:00 Mar 10 = EDT 23:00 Mar 9
+      // Inject a "now" on a different day so the "Today" label doesn't trigger
+      const notToday = dayjs.utc('2026-01-01T12:00:00Z').tz('America/New_York');
       const result = formatDateRange({
         dateStart: '2026-03-08T23:00:00Z',
         dateEnd: '2026-03-10T03:00:00Z',
         timezone: 'America/New_York',
         locale: 'en',
         day: true,
+        now: notToday,
       });
       // In EDT (UTC-4 in March), these are Mar 8 (Sun) and Mar 9 (Mon)
       expect(result).toEqual(['Sunday, March 8', 'Monday, March 9, 2026']);
@@ -764,6 +810,223 @@ describe('formatDateRange', () => {
         day: true,
       });
       expect(result).toEqual(['Sunday, March 8', 'Friday, March 13, 2026']);
+    });
+  });
+
+  describe('"Today" label', () => {
+    // Use a fixed "now" of Monday, March 9, 2026 12:00 UTC for all tests
+    const now = dayjs.utc('2026-03-09T12:00:00Z').tz('UTC');
+
+    describe('single date (no end date)', () => {
+      it('shows "Today" for a timed event starting today', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T14:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          now,
+        });
+        expect(result).toEqual([`Today 2:00${nbsp}PM`]);
+      });
+
+      it('shows "Today" for an all-day event today', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T00:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          day: true,
+          now,
+        });
+        expect(result).toEqual(['Today']);
+      });
+
+      it('does not show "Today" when date is not today', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-10T14:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          now,
+        });
+        expect(result).toEqual([`Tuesday, March 10, 2026 2:00${nbsp}PM`]);
+      });
+    });
+
+    describe('same-day timed events', () => {
+      it('replaces day name with "Today" for a same-day timed range', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T14:00:00Z',
+          dateEnd: '2026-03-09T17:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          now,
+        });
+        expect(result).toEqual(['Today 2:00', `5:00${nbsp}PM`]);
+      });
+
+      it('shows "Today" for same-day all-day event', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T00:00:00Z',
+          dateEnd: '2026-03-09T23:59:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          day: true,
+          now,
+        });
+        expect(result).toEqual(['Today']);
+      });
+    });
+
+    describe('multi-day ranges with "Today" on start', () => {
+      it('shows "Today" on start of a date-only multi-day range', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T00:00:00Z',
+          dateEnd: '2026-03-13T00:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          day: true,
+          now,
+        });
+        expect(result).toEqual(['Today', 'Friday, March 13, 2026']);
+      });
+
+      it('shows "Today" on start of a timed multi-day range', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T07:00:00Z',
+          dateEnd: '2026-03-13T17:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          now,
+        });
+        expect(result).toEqual([
+          `Today 7:00${nbsp}AM`,
+          `Friday, March 13, 2026 5:00${nbsp}PM`,
+        ]);
+      });
+    });
+
+    describe('multi-day ranges with "Today" on end', () => {
+      it('shows "Today" on end of a date-only multi-day range', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-07T00:00:00Z',
+          dateEnd: '2026-03-09T00:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          day: true,
+          now,
+        });
+        expect(result).toEqual(['Saturday, March 7', 'Today']);
+      });
+
+      it('shows "Today" on end of a timed multi-day range', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-07T10:00:00Z',
+          dateEnd: '2026-03-09T17:00:00Z',
+          timezone: 'UTC',
+          locale: 'en',
+          now,
+        });
+        expect(result).toEqual([
+          `Saturday, March 7 10:00${nbsp}AM`,
+          `Today 5:00${nbsp}PM`,
+        ]);
+      });
+    });
+
+    describe('timezone awareness', () => {
+      it('uses event timezone to determine "Today"', () => {
+        // 2026-03-09T23:00:00Z is still Mar 9 in UTC
+        // but it is Mar 10 in Helsinki (UTC+2)
+        const nowHel = dayjs.utc('2026-03-09T23:30:00Z').tz('Europe/Helsinki');
+        const result = formatDateRange({
+          dateStart: '2026-03-09T23:00:00Z',
+          timezone: 'Europe/Helsinki',
+          locale: 'en',
+          now: nowHel,
+        });
+        // In Helsinki this is Mar 10, and "now" is also Mar 10 in Helsinki
+        expect(result[0]).toMatch(/^Today/);
+      });
+
+      it('uses user timezone when useLocalTimezone is true', () => {
+        // Event is in UTC, but user is in US Pacific (UTC-7 in March)
+        // 2026-03-09T03:00:00Z is still Mar 8 in Pacific
+        const nowPac = dayjs
+          .utc('2026-03-09T09:00:00Z')
+          .tz('America/Los_Angeles');
+        const result = formatDateRange({
+          dateStart: '2026-03-09T03:00:00Z',
+          timezone: 'UTC',
+          useLocalTimezone: true,
+          userTimezone: 'America/Los_Angeles',
+          locale: 'en',
+          now: nowPac,
+        });
+        // In Pacific, the event is Mar 8 (8 PM), now is Mar 9 (2 AM)
+        // So this should NOT show "Today"
+        expect(result[0]).not.toMatch(/^Today/);
+      });
+
+      it('shows "Today" when event is today in user timezone', () => {
+        const nowPac = dayjs
+          .utc('2026-03-09T20:00:00Z')
+          .tz('America/Los_Angeles');
+        const result = formatDateRange({
+          dateStart: '2026-03-09T20:00:00Z',
+          timezone: 'Europe/London',
+          useLocalTimezone: true,
+          userTimezone: 'America/Los_Angeles',
+          locale: 'en',
+          now: nowPac,
+        });
+        // In Pacific, 20:00 UTC = 1:00 PM Mar 9, and now is also Mar 9
+        expect(result[0]).toMatch(/^Today/);
+      });
+    });
+
+    describe('locale support', () => {
+      it('shows "Heute" in German', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T14:00:00Z',
+          dateEnd: '2026-03-09T17:00:00Z',
+          timezone: 'UTC',
+          locale: 'de',
+          now,
+        });
+        expect(result[0]).toMatch(/^Heute/);
+      });
+
+      it('shows "Aujourd\'hui" in French', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T14:00:00Z',
+          dateEnd: '2026-03-09T17:00:00Z',
+          timezone: 'UTC',
+          locale: 'fr',
+          now,
+        });
+        expect(result[0]).toMatch(/^Aujourd'hui/);
+      });
+
+      it('shows "Hoy" in Spanish', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T14:00:00Z',
+          dateEnd: '2026-03-09T17:00:00Z',
+          timezone: 'UTC',
+          locale: 'es',
+          now,
+        });
+        expect(result[0]).toMatch(/^Hoy/);
+      });
+
+      it('shows "Heute" for multi-day date-only start in German', () => {
+        const result = formatDateRange({
+          dateStart: '2026-03-09T00:00:00Z',
+          dateEnd: '2026-03-13T00:00:00Z',
+          timezone: 'UTC',
+          locale: 'de',
+          day: true,
+          now,
+        });
+        expect(result).toEqual(['Heute', 'Freitag, 13. März 2026']);
+      });
     });
   });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -223,6 +223,44 @@ const RANGE_FORMATS: Record<
 };
 
 /**
+ * Locale-specific label for "Today".
+ *
+ * Used by formatDateRange to replace the day-of-week and date portion
+ * when a start or end date falls on the current calendar day in the
+ * resolved timezone.
+ */
+const TODAY_LABELS: Record<string, string> = {
+  en: 'Today',
+  de: 'Heute',
+  fr: "Aujourd'hui",
+  es: 'Hoy',
+};
+
+/**
+ * Checks whether a date falls on today's calendar day in the given timezone.
+ *
+ * Accepts an optional `now` parameter for testability; defaults to the
+ * real current time.
+ */
+export function isToday(
+  date: string | Date,
+  options: {
+    timezone?: string;
+    useLocalTimezone?: boolean;
+    userTimezone?: string;
+  },
+  now?: dayjs.Dayjs
+): boolean {
+  const tz = resolveTimezone(options);
+  const today = (now || dayjs()).tz(tz);
+  const isInternational = !options.timezone;
+  const target = isInternational
+    ? dayjs.utc(date).tz(tz)
+    : dayjs.utc(date).tz(tz);
+  return target.isSame(today, 'day');
+}
+
+/**
  * Locale-specific format strings for full-month display.
  *
  * When an event spans an entire calendar month (1st to last day),
@@ -297,20 +335,78 @@ export function formatDateRange(options: {
   day?: boolean;
   type?: string;
   isDeadline?: boolean;
+  /** Injected "now" for testability; defaults to the real current time. */
+  now?: dayjs.Dayjs;
 }): DateRangeParts {
   const locale = options.locale || 'en';
+  const todayLabel = TODAY_LABELS[locale] || TODAY_LABELS.en;
+
+  const isInternational = !options.timezone;
+  const tz = isInternational ? 'UTC' : resolveTimezone(options);
+  const nowInTz = (options.now || dayjs()).tz(tz);
+
+  /**
+   * Replaces the day-of-week + date portion of a formatted string with
+   * "Today" (or its locale equivalent) when `dateObj` falls on today.
+   *
+   * Accepts the dayjs format string used to produce `formatted` so it
+   * can strip the date-only prefix precisely for any locale. It removes
+   * the time tokens (LT / h:mm / H:mm / HH:mm) from the format to
+   * isolate the date prefix, then replaces that prefix in the output.
+   */
+  function today(
+    dateObj: dayjs.Dayjs,
+    formatted: string,
+    fmt?: string
+  ): string {
+    if (!dateObj.isSame(nowInTz, 'day')) return formatted;
+
+    // If we know the exact format, strip time tokens to get the date prefix
+    if (fmt) {
+      const dateOnlyFmt = fmt
+        .replace(/\s*LT$/, '')
+        .replace(/\s*h:mm\s*(A)?$/i, '')
+        .replace(/\s*H{1,2}:mm$/i, '')
+        .trim();
+      const datePrefix = dateObj.format(dateOnlyFmt);
+      if (formatted.startsWith(datePrefix)) {
+        return todayLabel + formatted.slice(datePrefix.length);
+      }
+    }
+
+    // Fallback: try common date-only patterns from longest to shortest
+    const dp = dayPrefix(locale);
+    const candidates = [
+      dateObj.format(`${dp}LL`), // "Sunday, March 8, 2026"
+      dateObj.format(`${dp}MMMM D, YYYY`), // explicit with year
+      dateObj.format(`${dp}MMMM D`), // without year
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate && formatted.startsWith(candidate)) {
+        return todayLabel + formatted.slice(candidate.length);
+      }
+    }
+    return formatted;
+  }
 
   // No end date — return a single formatted date
   if (!options.dateEnd) {
     const format = getStartDateFormat(options);
-    return [formatEventDate(options.dateStart, format, options)];
+    const startDj = isInternational
+      ? dayjs.utc(options.dateStart).locale(locale)
+      : dayjs.utc(options.dateStart).tz(tz).locale(locale);
+    return [
+      today(
+        startDj,
+        formatEventDate(options.dateStart, format, options),
+        format
+      ),
+    ];
   }
 
   const isDateOnly =
     options.day || options.type === 'theme' || options.isDeadline;
-
-  const isInternational = !options.timezone;
-  const tz = isInternational ? 'UTC' : resolveTimezone(options);
 
   // Resolve dayjs instances in the target timezone
   const start = isInternational
@@ -325,11 +421,17 @@ export function formatDateRange(options: {
   // Same day — timed events show "date time" / "time", date-only returns single date
   if (start.isSame(end, 'day')) {
     if (isDateOnly) {
-      return [nonBreakingTime(start.format(`${dp}LL`))];
+      return [
+        today(start, nonBreakingTime(start.format(`${dp}LL`)), `${dp}LL`),
+      ];
     }
     const startTime = deduplicateAmPm(start, end, locale);
     return [
-      nonBreakingTime(`${start.format(`${dp}LL`)} ${startTime}`),
+      today(
+        start,
+        nonBreakingTime(`${start.format(`${dp}LL`)} ${startTime}`),
+        `${dp}LL`
+      ),
       nonBreakingTime(end.format('LT')),
     ];
   }
@@ -340,13 +442,29 @@ export function formatDateRange(options: {
   if (!isDateOnly) {
     if (start.isSame(end, 'year')) {
       return [
-        nonBreakingTime(start.format(formats.timedSameYear.start)),
-        nonBreakingTime(end.format(formats.timedSameYear.end)),
+        today(
+          start,
+          nonBreakingTime(start.format(formats.timedSameYear.start)),
+          formats.timedSameYear.start
+        ),
+        today(
+          end,
+          nonBreakingTime(end.format(formats.timedSameYear.end)),
+          formats.timedSameYear.end
+        ),
       ];
     }
     return [
-      nonBreakingTime(start.format(formats.timedDiffYear.start)),
-      nonBreakingTime(end.format(formats.timedDiffYear.end)),
+      today(
+        start,
+        nonBreakingTime(start.format(formats.timedDiffYear.start)),
+        formats.timedDiffYear.start
+      ),
+      today(
+        end,
+        nonBreakingTime(end.format(formats.timedDiffYear.end)),
+        formats.timedDiffYear.end
+      ),
     ];
   }
 
@@ -362,15 +480,23 @@ export function formatDateRange(options: {
       ? formats.sameMonth
       : formats.diffMonth;
     return [
-      nonBreakingTime(start.format(fmt.start)),
-      nonBreakingTime(end.format(fmt.end)),
+      today(start, nonBreakingTime(start.format(fmt.start)), fmt.start),
+      today(end, nonBreakingTime(end.format(fmt.end)), fmt.end),
     ];
   }
 
   // Different years: no deduplication possible
   return [
-    nonBreakingTime(start.format(formats.dateOnlyDiffYear.start)),
-    nonBreakingTime(end.format(formats.dateOnlyDiffYear.end)),
+    today(
+      start,
+      nonBreakingTime(start.format(formats.dateOnlyDiffYear.start)),
+      formats.dateOnlyDiffYear.start
+    ),
+    today(
+      end,
+      nonBreakingTime(end.format(formats.dateOnlyDiffYear.end)),
+      formats.dateOnlyDiffYear.end
+    ),
   ];
 }
 


### PR DESCRIPTION
## Summary

- When a start or end date falls on the current calendar day in the user's resolved timezone, replaces the day-of-week and date portion (e.g. "Monday, March 9") with a locale-aware "Today" label (`Today`, `Heute`, `Aujourd'hui`, `Hoy`)
- Adds `isToday()` exported helper and `TODAY_LABELS` constant to `dateUtils.ts`, plus a `now` parameter on `formatDateRange()` for testability
- Adds 20 new test cases covering timezone awareness, `useLocalTimezone` support, all four locales, and single/multi-day ranges for both start and end dates

## Examples

| Before | After |
|---|---|
| Monday, March 9 7:00 AM – Friday, March 13, 2026 5:00 PM | Today 7:00 AM – Friday, March 13, 2026 5:00 PM |
| Saturday, March 7 – Monday, March 9, 2026 | Saturday, March 7 – Today |
| Monday, March 9, 2026 2:00 PM | Today 2:00 PM |

## Notes

- The SSR fallback (`StaticEvent.astro`) is unchanged since user timezone is unknown during server rendering
- One pre-existing test that coincidentally used today's real date was updated to inject a fixed `now` so it remains a pure timezone test