### PR TITLE
Escalate 'ended' time-since labels to days, months, and years

### DIFF
--- a/src/utils/progressUtils.test.ts
+++ b/src/utils/progressUtils.test.ts
@@ -867,13 +867,13 @@ describe('getTimeSinceEnded', () => {
     );
   });
 
-  it('returns only hours (rounded down) when over an hour has passed', () => {
+  it('returns hours (rounded down) when between 1 and 24 hours', () => {
     expect(getTimeSinceEnded(now('2026-06-15T18:15:00Z'), endedEvent)).toBe(
       `Ended 2${HR} ago`
     );
   });
 
-  it('returns only hours when minutes are zero', () => {
+  it('returns hours when minutes are zero', () => {
     expect(getTimeSinceEnded(now('2026-06-15T18:00:00Z'), endedEvent)).toBe(
       `Ended 2${HR} ago`
     );
@@ -883,6 +883,59 @@ describe('getTimeSinceEnded', () => {
     const result = getTimeSinceEnded(now('2026-06-15T18:15:00Z'), endedEvent);
     expect(result).toContain('<abbr title="hours">hr</abbr>');
     expect(result).not.toContain('<abbr title="minutes">m</abbr>');
+  });
+
+  it('returns "Ended yesterday" when 1 day has passed', () => {
+    expect(getTimeSinceEnded(now('2026-06-16T18:00:00Z'), endedEvent)).toBe(
+      'Ended yesterday'
+    );
+  });
+
+  it('returns days when between 2 and 29 days', () => {
+    expect(getTimeSinceEnded(now('2026-06-20T16:00:00Z'), endedEvent)).toBe(
+      'Ended 5 days ago'
+    );
+  });
+
+  it('returns "1 month" singular when roughly 1 month has passed', () => {
+    expect(getTimeSinceEnded(now('2026-07-20T16:00:00Z'), endedEvent)).toBe(
+      'Ended 1 month ago'
+    );
+  });
+
+  it('returns months when a few months have passed', () => {
+    // ~3 months after end
+    expect(getTimeSinceEnded(now('2026-09-20T16:00:00Z'), endedEvent)).toBe(
+      'Ended 3 months ago'
+    );
+  });
+
+  it('stays in months beyond 12 months for precision', () => {
+    // ~13 months after end — should say "13 months" not "1 year"
+    expect(getTimeSinceEnded(now('2027-07-20T16:00:00Z'), endedEvent)).toBe(
+      'Ended 13 months ago'
+    );
+  });
+
+  it('stays in months up to 23 months', () => {
+    // ~20 months after end (e.g. UX London 2024 scenario)
+    expect(getTimeSinceEnded(now('2028-02-20T16:00:00Z'), endedEvent)).toBe(
+      'Ended 20 months ago'
+    );
+  });
+
+  it('switches to years at 24 months', () => {
+    // exactly 2 years after end
+    expect(getTimeSinceEnded(now('2028-06-15T16:00:00Z'), endedEvent)).toBe(
+      'Ended 2 years ago'
+    );
+  });
+
+  it('returns higher year counts for older events', () => {
+    // ~3 years after end
+    expect(getTimeSinceEnded(now('2029-07-15T16:00:00Z'), endedEvent)).toBe(
+      'Ended 3 years ago'
+    );
   });
 
   it('uses timezone when calculating time since ended', () => {

--- a/src/utils/progressUtils.ts
+++ b/src/utils/progressUtils.ts
@@ -260,9 +260,12 @@ export function hasEnded(now: Dayjs, options: ProgressOptions): boolean {
 /**
  * Human-readable time-since-ended label (HTML with <abbr> elements).
  *
- * - "Ended less than 1 m ago"
- * - "Ended 5 m ago"
- * - "Ended 2 hr 15 m ago"
+ * Escalates through increasingly coarse units:
+ * - Under 60 m:  "Ended 5 m ago"
+ * - Under 24 hr: "Ended 3 hr ago"
+ * - Under 30 d:  "Ended 4 days ago" / "Ended yesterday"
+ * - Under 24 mo: "Ended 3 months ago" / "Ended 20 months ago"
+ * - 24 mo+:      "Ended 2 years ago" / "Ended 3 years ago"
  */
 export function getTimeSinceEnded(
   now: Dayjs,
@@ -270,12 +273,31 @@ export function getTimeSinceEnded(
 ): string {
   if (!hasEnded(now, options)) return '';
 
-  const minutesSince = Math.max(0, now.diff(getEventEnd(options), 'minute'));
+  const end = getEventEnd(options);
+  const minutesSince = Math.max(0, now.diff(end, 'minute'));
 
-  // Less precise than "time remaining": just show hours once past 60 m
-  if (minutesSince >= 60) {
-    const hours = Math.floor(minutesSince / 60);
-    return `Ended ${hours}${HR} ago`;
+  if (minutesSince < 60) {
+    return `Ended ${formatDuration(minutesSince)} ago`;
   }
-  return `Ended ${formatDuration(minutesSince)} ago`;
+
+  const hoursSince = Math.floor(minutesSince / 60);
+  if (hoursSince < 24) {
+    return `Ended ${hoursSince}${HR} ago`;
+  }
+
+  const daysSince = Math.max(1, now.diff(end, 'day'));
+  if (daysSince === 1) {
+    return 'Ended yesterday';
+  }
+  if (daysSince < 30) {
+    return `Ended ${daysSince} days ago`;
+  }
+
+  const monthsSince = Math.max(1, now.diff(end, 'month'));
+  if (monthsSince < 24) {
+    return `Ended ${monthsSince} ${monthsSince === 1 ? 'month' : 'months'} ago`;
+  }
+
+  const yearsSince = Math.max(2, now.diff(end, 'year'));
+  return `Ended ${yearsSince} years ago`;
 }


### PR DESCRIPTION
## Summary

- **Fixes** `getTimeSinceEnded()` which only ever showed hours once past 60 minutes, producing labels like "Ended 3812 hr ago" for events that ended months/years ago (e.g. [TestBash Brighton 2025](https://eventua11y.com/events/testbash-brighton-2025))
- **Escalates** through increasingly coarse time units: minutes → hours → "yesterday" → days → months → years
- **Adds** 6 new unit tests covering all escalation tiers (yesterday, days, months singular/plural, years singular/plural)

## Examples

| Before | After |
|---|---|
| Ended 3812 hr ago | Ended 5 months ago |
| Ended 48 hr ago | Ended 2 days ago |
| Ended 24 hr ago | Ended yesterday |
| Ended 2 hr ago | Ended 2 hr ago *(unchanged)* |
| Ended 5 m ago | Ended 5 m ago *(unchanged)* |