### PR TITLE
Deduplicate Sanity client in sitemap endpoint

### DIFF
--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -35,7 +35,7 @@ import {
 
 // ── Sanity client ──────────────────────────────────────────────────────
 
-function getSanityClient() {
+export function getSanityClient() {
   return createClient({
     projectId: import.meta.env.SANITY_PROJECT,
     dataset: import.meta.env.SANITY_DATASET,

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -17,7 +17,7 @@
  */
 
 import type { APIRoute } from 'astro';
-import { createClient } from '@sanity/client';
+import { getSanityClient } from '../lib/sanity';
 
 export const prerender = false;
 
@@ -31,12 +31,7 @@ interface SitemapEvent {
  * Only includes events that have a slug (required to generate a URL).
  */
 async function getEventSlugs(): Promise<SitemapEvent[]> {
-  const client = createClient({
-    projectId: import.meta.env.SANITY_PROJECT,
-    dataset: import.meta.env.SANITY_DATASET,
-    apiVersion: import.meta.env.SANITY_API_VERSION || '2021-03-25',
-    useCdn: true, // CDN is fine for sitemap reads
-  });
+  const client = getSanityClient();
 
   return client.fetch<SitemapEvent[]>(`
     *[_type == "event" && defined(slug.current) && !(_id in path("drafts.**"))] {


### PR DESCRIPTION
## Summary

- **Exports `getSanityClient()`** from `src/lib/sanity.ts` (was private, now public)
- **Replaces the duplicate client creation** in `src/pages/sitemap.xml.ts` with an import

## What changed

The sitemap endpoint was creating its own Sanity client with config identical to `getSanityClient()` in `sanity.ts`. This is the last remaining Sanity client duplication on the Node/Astro side (the edge function client was already deduplicated in #679).

The two standalone CLI scripts (`scripts/backfill-slugs.mjs` and `scripts/check-event-freshness.mjs`) intentionally keep their own clients — they use `process.env`, different API versions, and `backfill-slugs` needs a write token.

## Minor behaviour change

The sitemap previously hardcoded `useCdn: true`. It now reads from the `SANITY_CDN` env var like the rest of the SSR layer (`true` in production, `false` in preview/dev). This is the correct behaviour — preview deploys should see fresh data.

## Verification

All 273 unit tests pass. Knip clean. Prettier clean. Astro build succeeds.