### PR TITLE
Fix hackathon format displaying in lowercase

### DIFF
--- a/src/utils/eventUtils.test.ts
+++ b/src/utils/eventUtils.test.ts
@@ -431,10 +431,11 @@ describe('getFormatLabel', () => {
     expect(getFormatLabel('workshop')).toBe('Workshop');
     expect(getFormatLabel('qna')).toBe('Q&A');
     expect(getFormatLabel('keynote')).toBe('Keynote');
+    expect(getFormatLabel('hackathon')).toBe('Hackathon');
   });
 
   it('falls back to the raw format string for unknown formats', () => {
-    expect(getFormatLabel('hackathon')).toBe('hackathon');
+    expect(getFormatLabel('unconference')).toBe('unconference');
   });
 
   it('returns undefined for undefined input', () => {
@@ -454,10 +455,11 @@ describe('getFormatPreposition', () => {
   it('returns "with" for collaborative formats', () => {
     expect(getFormatPreposition('workshop')).toBe('with');
     expect(getFormatPreposition('panel')).toBe('with');
+    expect(getFormatPreposition('hackathon')).toBe('with');
   });
 
   it('defaults to "by" for unknown formats', () => {
-    expect(getFormatPreposition('hackathon')).toBe('by');
+    expect(getFormatPreposition('unconference')).toBe('by');
   });
 
   it('defaults to "by" for undefined input', () => {

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -177,6 +177,7 @@ export const FORMAT_LABELS: Record<string, string> = {
   qna: 'Q&A',
   keynote: 'Keynote',
   roundtable: 'Roundtable',
+  hackathon: 'Hackathon',
 };
 
 /**
@@ -194,6 +195,7 @@ const FORMAT_PREPOSITIONS: Record<string, string> = {
   qna: 'with',
   keynote: 'by',
   roundtable: 'with',
+  hackathon: 'with',
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `hackathon` to `FORMAT_LABELS` (→ "Hackathon") and `FORMAT_PREPOSITIONS` (→ "with") in `eventUtils.ts`, fixing the event type appearing as lowercase "hackathon" on detail pages like [/events/open-source-assistive-technology-hackathon](https://eventua11y.com/events/open-source-assistive-technology-hackathon).
- Updates tests to cover the new mapping and uses `'unconference'` as the example for unknown-format fallback behavior.

## Root cause

The `FORMAT_LABELS` lookup map didn't include `hackathon`, so `getFormatLabel('hackathon')` fell through to the raw string fallback, returning the lowercase value directly from Sanity.