### PR TITLE
Centralise dayjs plugin imports into a single module

### DIFF
--- a/src/components/EventDate.vue
+++ b/src/components/EventDate.vue
@@ -31,22 +31,13 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import EventProgress from './EventProgress.vue';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezonePlugin from 'dayjs/plugin/timezone';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
-import advancedFormat from 'dayjs/plugin/advancedFormat';
+import dayjs from '../lib/dayjs';
 import userStore from '../store/userStore';
 import { formatEventDate, formatDateRange } from '../utils/dateUtils';
 import 'dayjs/locale/en';
 import 'dayjs/locale/es';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/de';
-
-dayjs.extend(utc);
-dayjs.extend(timezonePlugin);
-dayjs.extend(localizedFormat);
-dayjs.extend(advancedFormat);
 
 const locale = userStore.locale || 'en';
 dayjs.locale(locale);

--- a/src/components/EventList.vue
+++ b/src/components/EventList.vue
@@ -6,18 +6,8 @@ import Skeleton from './Skeleton.vue';
 import userStore from '../store/userStore';
 import filtersStore from '../store/filtersStore';
 import type { Event as EventType, Book } from '../types/event';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '../lib/dayjs';
 import { getYearMonth as _getYearMonth } from '../utils/dateUtils';
-import {
-  groupByMonth,
-  filterPastMonths,
-  formatMonthHeading,
-} from '../utils/eventUtils';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 type ListItem = EventType | Book;
 type GroupedEvents = Record<string, ListItem[]>;

--- a/src/components/EventList.vue
+++ b/src/components/EventList.vue
@@ -8,6 +8,11 @@ import filtersStore from '../store/filtersStore';
 import type { Event as EventType, Book } from '../types/event';
 import dayjs from '../lib/dayjs';
 import { getYearMonth as _getYearMonth } from '../utils/dateUtils';
+import {
+  groupByMonth,
+  filterPastMonths,
+  formatMonthHeading,
+} from '../utils/eventUtils';
 
 type ListItem = EventType | Book;
 type GroupedEvents = Record<string, ListItem[]>;

--- a/src/components/EventProgress.vue
+++ b/src/components/EventProgress.vue
@@ -29,23 +29,8 @@
 
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted } from 'vue';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezonePlugin from 'dayjs/plugin/timezone';
+import dayjs from '../lib/dayjs';
 import userStore from '../store/userStore';
-import {
-  isHappeningNow as _isHappeningNow,
-  isStartingSoon as _isStartingSoon,
-  hasEnded as _hasEnded,
-  getProgress,
-  getTimeRemaining,
-  getCountdownLabel,
-  getTimeSinceEnded,
-  type ProgressOptions,
-} from '../utils/progressUtils';
-
-dayjs.extend(utc);
-dayjs.extend(timezonePlugin);
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/EventProgress.vue
+++ b/src/components/EventProgress.vue
@@ -31,6 +31,16 @@
 import { computed, ref, onMounted, onUnmounted } from 'vue';
 import dayjs from '../lib/dayjs';
 import userStore from '../store/userStore';
+import {
+  isHappeningNow as _isHappeningNow,
+  isStartingSoon as _isStartingSoon,
+  hasEnded as _hasEnded,
+  getProgress,
+  getTimeRemaining,
+  getCountdownLabel,
+  getTimeSinceEnded,
+  type ProgressOptions,
+} from '../utils/progressUtils';
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -6,15 +6,8 @@
  * HTML without any client-side interactivity.
  * It uses UTC dates since user timezone is unknown during SSR.
  */
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
+import dayjs from '../lib/dayjs';
 import type { Event } from '../types/event';
-import { getEventUrl } from '../utils/eventUtils';
-import { formatDateRange } from '../utils/dateUtils';
-
-dayjs.extend(utc);
-dayjs.extend(localizedFormat);
 
 interface Props {
   event: Event;

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -8,6 +8,8 @@
  */
 import dayjs from '../lib/dayjs';
 import type { Event } from '../types/event';
+import { getEventUrl } from '../utils/eventUtils';
+import { formatDateRange } from '../utils/dateUtils';
 
 interface Props {
   event: Event;

--- a/src/components/StaticEventList.astro
+++ b/src/components/StaticEventList.astro
@@ -19,9 +19,7 @@ import {
   formatMonthHeading,
 } from '../utils/eventUtils';
 import type { Event, Book } from '../types/event';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-dayjs.extend(utc);
+import dayjs from '../lib/dayjs';
 
 interface Props {
   type: 'upcoming' | 'past';

--- a/src/components/TimezoneSelector.vue
+++ b/src/components/TimezoneSelector.vue
@@ -19,12 +19,7 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue';
 import userStore from '../store/userStore';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import dayjs from '../lib/dayjs';
 
 withDefaults(
   defineProps<{

--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -41,6 +41,7 @@ import { computed, ref, onMounted, watch } from 'vue';
 import userStore from '../store/userStore';
 import dayjs from '../lib/dayjs';
 import Event from './Event.vue';
+import filtersStore from '../store/filtersStore';
 
 // Get the start of the day using the timezone from the edge function
 const today = computed(() => {

--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -39,14 +39,8 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, watch } from 'vue';
 import userStore from '../store/userStore';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '../lib/dayjs';
 import Event from './Event.vue';
-import filtersStore from '../store/filtersStore';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 // Get the start of the day using the timezone from the edge function
 const today = computed(() => {

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,0 +1,24 @@
+/**
+ * Pre-configured dayjs instance with all plugins used across the app.
+ *
+ * Import dayjs from this module instead of 'dayjs' directly to avoid
+ * repeating plugin imports and dayjs.extend() calls in every file.
+ *
+ * The edge function (netlify/edge-functions/get-events.ts) maintains
+ * its own setup because it uses Deno-style esm.sh imports.
+ */
+
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(localizedFormat);
+dayjs.extend(advancedFormat);
+dayjs.extend(isSameOrAfter);
+
+export default dayjs;

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -11,14 +11,7 @@
  */
 
 import { createClient } from '@sanity/client';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.extend(isSameOrAfter);
+import dayjs from './dayjs';
 
 import type { PortableTextBlock } from '@portabletext/types';
 import type { Event, Book } from '../types/event';

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import dayjs from '../lib/dayjs';
 
 /** Non-breaking space used between time digits and AM/PM */
 const nbsp = '\u00A0';

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,15 +1,8 @@
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-import localizedFormat from 'dayjs/plugin/localizedFormat';
+import dayjs from '../lib/dayjs';
 import 'dayjs/locale/en';
 import 'dayjs/locale/de';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/es';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
-dayjs.extend(localizedFormat);
 
 /**
  * Returns the day-of-week prefix for a given locale.

--- a/src/utils/progressUtils.test.ts
+++ b/src/utils/progressUtils.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '../lib/dayjs';
 import {
   getEventStart,
   getEventEnd,
@@ -18,9 +16,6 @@ import {
   getTimeSinceEnded,
   type ProgressOptions,
 } from './progressUtils';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/utils/progressUtils.ts
+++ b/src/utils/progressUtils.ts
@@ -1,10 +1,6 @@
-import dayjs, { type Dayjs } from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
+import dayjs from '../lib/dayjs';
+import type { Dayjs } from 'dayjs';
 import { resolveTimezone } from './dateUtils';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 /** Wraps time abbreviations in <abbr> elements. */
 const HR = ' <abbr title="hours">hr</abbr>';


### PR DESCRIPTION
## Summary

- Creates `src/lib/dayjs.ts` — a single module that imports dayjs, extends it with all 5 plugins (`utc`, `timezone`, `localizedFormat`, `advancedFormat`, `isSameOrAfter`), and re-exports the configured instance.
- Updates 12 files across components, utilities, and tests to import from this centralised module instead of repeating individual plugin imports and `dayjs.extend()` calls.
- Net reduction of ~58 lines of duplicated boilerplate.

## What changed

| File | Change |
|------|--------|
| `src/lib/dayjs.ts` | **New** — centralised dayjs module |
| `src/lib/sanity.ts` | Import from `./dayjs` |
| `src/utils/dateUtils.ts` | Import from `../lib/dayjs` |
| `src/utils/progressUtils.ts` | Import from `../lib/dayjs` |
| `src/utils/dateUtils.test.ts` | Import from `../lib/dayjs` |
| `src/utils/progressUtils.test.ts` | Import from `../lib/dayjs` |
| `src/components/EventDate.vue` | Import from `../lib/dayjs` |
| `src/components/EventList.vue` | Import from `../lib/dayjs` |
| `src/components/EventProgress.vue` | Import from `../lib/dayjs` |
| `src/components/StaticEvent.astro` | Import from `../lib/dayjs` |
| `src/components/StaticEventList.astro` | Import from `../lib/dayjs` |
| `src/components/TimezoneSelector.vue` | Import from `../lib/dayjs` |
| `src/components/Today.vue` | Import from `../lib/dayjs` |

## Not changed (intentionally)

- `netlify/edge-functions/get-events.ts` — Deno runtime uses `https://esm.sh/` imports, cannot share Node modules
- `scripts/check-event-freshness.mjs` — standalone CLI script with its own minimal dayjs setup

## Verification

- `npm run check` ✅ (Prettier)
- `npm run test:unit` ✅ (273/273 tests pass)
- `npm run knip` ✅ (no unused exports)