### PR TITLE
Use module-level Sanity client singleton

### DIFF
--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -35,13 +35,18 @@ import {
 
 // ── Sanity client ──────────────────────────────────────────────────────
 
+const sanityClient = createClient({
+  projectId: import.meta.env.SANITY_PROJECT,
+  dataset: import.meta.env.SANITY_DATASET,
+  apiVersion: import.meta.env.SANITY_API_VERSION || '2021-03-25',
+  useCdn: import.meta.env.SANITY_CDN === 'true',
+});
+
+/**
+ * Returns the shared Sanity client instance.
+ */
 export function getSanityClient() {
-  return createClient({
-    projectId: import.meta.env.SANITY_PROJECT,
-    dataset: import.meta.env.SANITY_DATASET,
-    apiVersion: import.meta.env.SANITY_API_VERSION || '2021-03-25',
-    useCdn: import.meta.env.SANITY_CDN === 'true',
-  });
+  return sanityClient;
 }
 
 // ── Event queries (mirrors the edge function GROQ) ─────────────────────
@@ -79,7 +84,7 @@ export async function getEvents(): Promise<{
   future: Event[];
   past: Event[];
 }> {
-  const client = getSanityClient();
+  const client = sanityClient;
 
   const [parentEvents, childEvents]: [AssemblableEvent[], AssemblableEvent[]] =
     await Promise.all([
@@ -160,7 +165,7 @@ export async function getEventBySlug(slug: string): Promise<Event | null> {
     return cached.data;
   }
 
-  const client = getSanityClient();
+  const client = sanityClient;
 
   const event: RawEvent | null = await client.fetch(
     `
@@ -220,7 +225,7 @@ interface RawBook {
  * expected by the event list components.
  */
 export async function getBooks(): Promise<Book[]> {
-  const client = getSanityClient();
+  const client = sanityClient;
 
   const rawBooks: RawBook[] = await client.fetch(BOOKS_QUERY);
 


### PR DESCRIPTION
## Summary

- Creates the Sanity client once at module level in `src/lib/sanity.ts` instead of constructing a new instance on every function call.
- Internal functions (`getEvents`, `getEventBySlug`, `getBooks`) now reference the module-level constant directly.
- `getSanityClient()` is kept as a thin accessor for external callers (`sitemap.xml.ts`).

## Why

The `import.meta.env` values used to configure the client are static per server instance — there's no reason to recreate the client object on every API call. This eliminates unnecessary object allocation and makes the singleton pattern explicit.

## Verification

- `npm run check` ✅ (Prettier)
- `npm run test:unit` ✅ (273/273 tests pass)
- `npm run knip` ✅ (no unused exports)