### PR TITLE
Fix sidebar card not appearing on first navigation

### DIFF
--- a/src/styles/_reset.css
+++ b/src/styles/_reset.css
@@ -74,11 +74,3 @@ select {
     scroll-behavior: auto !important;
   }
 }
-
-/* Hide custom elements that are not yet registered to prevent FOUCE.
-   Skeleton placeholders use native HTML/CSS so they are unaffected by
-   this rule and render immediately. */
-:not(:defined) {
-  display: none;
-  visibility: hidden;
-}


### PR DESCRIPTION
## Summary

Removes the blanket `:not(:defined) { display: none; visibility: hidden }` rule from `_reset.css` that was hiding unregistered Web Awesome custom elements.

Closes #625. Supersedes #626.

## The problem

On first visit to an event detail page (cold cache), the sidebar `<wa-card>` containing the website link and organiser info didn't appear. It only rendered after a full page refresh.

The custom CSS rule removed all undefined custom elements from layout flow with `display: none`. On cold loads, CSS loaded before the Web Awesome JS bundle could register elements, creating a race condition — some elements never recovered their visibility.

## Why this fix (and not #626)

PR #626 replaced the rule with Web Awesome's `wa-cloak` utility, which hides the **entire page** with `opacity: 0` for up to 2 seconds while any `wa-*` element is undefined. That traded one problem for another:

- The skeleton loading pattern (pure HTML/CSS) would be hidden instead of rendering immediately
- On slow connections, users would see a blank page for up to 2 seconds
- It was disproportionate — hiding the entire site to fix one sidebar card

Simply removing the rule is sufficient because:

- Undefined custom elements render as empty inline elements with no visual footprint — there is no meaningful FOUCE to prevent
- The skeleton loading pattern continues to render immediately during hydration
- Web Awesome components render smoothly in place once their JS registers them

## Verification

- `npm run check` ✅ (Prettier)
- `npm run test:unit` ✅ (273/273 tests pass)
- `npm run knip` ✅