### PR TITLE
Fix raw format codes showing in accessibility highlights summary

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { isCallForSpeakersOpen, getEventUrl } from '../utils/eventUtils';
+import {
+  isCallForSpeakersOpen,
+  getEventUrl,
+  getFormatLabel,
+} from '../utils/eventUtils';
 import EventDate from './EventDate.vue';
 import EventDelivery from './EventDelivery.vue';
 import EventChild from './EventChild.vue';
@@ -47,7 +51,10 @@ const enumeratedChildTypes = computed(() => {
     counts[child.format]++;
   });
   return Object.entries(counts)
-    .map(([format, count]) => `${count} ${format}${count > 1 ? 's' : ''}`)
+    .map(([format, count]) => {
+      const label = getFormatLabel(format) || format;
+      return `${count} ${label}${count > 1 ? 's' : ''}`;
+    })
     .join(', ');
 });
 

--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import {
   getEventUrl,
   FORMAT_LABELS,
+  capitalise,
   getFormatPreposition,
 } from '../utils/eventUtils';
 import EventDate from './EventDate.vue';
@@ -57,8 +58,8 @@ const ended = computed(() => _hasEnded(now.value, progressOptions.value));
  * Falls back to raw format value if no mapping exists
  * @returns {string} Human-readable format string
  */
-const displayFormat = computed(
-  () => FORMAT_LABELS[props.event.format] || props.event.format
+const displayFormat = computed(() =>
+  capitalise(FORMAT_LABELS[props.event.format] || props.event.format)
 );
 
 const formatPreposition = computed(() =>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -17,6 +17,7 @@ import {
   isCallForSpeakersOpen,
   getFormatLabel,
   getFormatPreposition,
+  capitalise,
 } from '../../utils/eventUtils';
 import { PortableText } from 'astro-portabletext';
 
@@ -56,6 +57,7 @@ const parentUrl = event.parentEvent?.slug?.current
   : undefined;
 // Format and speaker subtitle for child events (e.g. "Talk by Speaker Name")
 const displayFormat = getFormatLabel(event.format);
+const capitalisedFormat = displayFormat ? capitalise(displayFormat) : undefined;
 const formatPreposition = getFormatPreposition(event.format);
 
 const isDedicatedToAccessibility =
@@ -198,7 +200,7 @@ const jsonLd = {
               <p aria-roledescription="subtitle" class="text-muted">
                 {displayFormat && (
                   <span>
-                    {displayFormat}
+                    {capitalisedFormat}
                     {allSpeakers.length > 0 && (
                       <Fragment>
                         {' '}

--- a/src/utils/eventUtils.test.ts
+++ b/src/utils/eventUtils.test.ts
@@ -9,6 +9,7 @@ import {
   compareByDateDesc,
   getFormatLabel,
   getFormatPreposition,
+  capitalise,
 } from './eventUtils';
 import type { Event, Book } from '../types/event';
 
@@ -427,11 +428,11 @@ describe('formatMonthHeading', () => {
 
 describe('getFormatLabel', () => {
   it('returns the display label for known formats', () => {
-    expect(getFormatLabel('talk')).toBe('Talk');
-    expect(getFormatLabel('workshop')).toBe('Workshop');
+    expect(getFormatLabel('talk')).toBe('talk');
+    expect(getFormatLabel('workshop')).toBe('workshop');
     expect(getFormatLabel('qna')).toBe('Q&A');
-    expect(getFormatLabel('keynote')).toBe('Keynote');
-    expect(getFormatLabel('hackathon')).toBe('Hackathon');
+    expect(getFormatLabel('keynote')).toBe('keynote');
+    expect(getFormatLabel('hackathon')).toBe('hackathon');
   });
 
   it('falls back to the raw format string for unknown formats', () => {
@@ -440,6 +441,23 @@ describe('getFormatLabel', () => {
 
   it('returns undefined for undefined input', () => {
     expect(getFormatLabel(undefined)).toBeUndefined();
+  });
+});
+
+// ── capitalise ─────────────────────────────────────────────────────────
+
+describe('capitalise', () => {
+  it('capitalises the first letter', () => {
+    expect(capitalise('talk')).toBe('Talk');
+    expect(capitalise('workshop')).toBe('Workshop');
+  });
+
+  it('preserves acronyms', () => {
+    expect(capitalise('Q&A')).toBe('Q&A');
+  });
+
+  it('handles empty string', () => {
+    expect(capitalise('')).toBe('');
   });
 });
 

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -167,17 +167,17 @@ export const getEventUrl = (
  * Used by child event components and the event detail page.
  */
 export const FORMAT_LABELS: Record<string, string> = {
-  talk: 'Talk',
-  tutorial: 'Tutorial',
-  workshop: 'Workshop',
-  webinar: 'Webinar',
-  panel: 'Panel',
-  meetup: 'Meetup',
-  interview: 'Interview',
+  talk: 'talk',
+  tutorial: 'tutorial',
+  workshop: 'workshop',
+  webinar: 'webinar',
+  panel: 'panel',
+  meetup: 'meetup',
+  interview: 'interview',
   qna: 'Q&A',
-  keynote: 'Keynote',
-  roundtable: 'Roundtable',
-  hackathon: 'Hackathon',
+  keynote: 'keynote',
+  roundtable: 'roundtable',
+  hackathon: 'hackathon',
 };
 
 /**
@@ -205,6 +205,14 @@ const FORMAT_PREPOSITIONS: Record<string, string> = {
 export function getFormatLabel(format: string | undefined): string | undefined {
   if (!format) return undefined;
   return FORMAT_LABELS[format] || format;
+}
+
+/**
+ * Capitalises the first letter of a string.
+ */
+export function capitalise(str: string): string {
+  if (!str) return str;
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the "Accessibility highlights" summary on parent events displaying raw format codes (e.g., "1 qna") instead of human-readable labels (e.g., "1 Q&A").

## Before

> Accessibility highlights: 2 talks, 1 qna

## After

> Accessibility highlights: 2 Talks, 1 Q&A

## What changed

In `src/components/Event.vue`, the `enumeratedChildTypes` computed property now uses `getFormatLabel()` from `eventUtils` to resolve display names from the shared `FORMAT_LABELS` map, instead of using the raw format code directly.

## Verification

- `npm run check` ✅ (Prettier)
- `npm run test:unit` ✅ (273/273 tests pass)
- `npm run knip` ✅