### PR TITLE
Fix event container IDs to match test selectors

### DIFF
--- a/src/components/EventList.vue
+++ b/src/components/EventList.vue
@@ -180,7 +180,7 @@ watch(
     </wa-callout>
 
     <!-- Events list -->
-    <div :id="`${type}-events`" v-else class="flow flow-2xl">
+    <div v-else class="flow flow-2xl">
       <section
         v-for="(events, yearMonth) in groupedEvents"
         :key="yearMonth"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,7 +26,7 @@ Astro.response.headers.set(
   <Filters client:only="vue" />
   <div class="container grid">
     <div
-      id="events"
+      id="upcoming-events"
       role="region"
       aria-labelledby="upcoming-events-heading"
       class="py-l readable main-content"
@@ -43,7 +43,7 @@ Astro.response.headers.set(
       id="month-nav"
       class="mb-l"
       client:idle
-      contentRegion="#events"
+      contentRegion="#upcoming-events"
       showTodayLink={true}
     />
   </div>

--- a/src/pages/past-events.astro
+++ b/src/pages/past-events.astro
@@ -18,7 +18,7 @@ Astro.response.headers.set(
 <DefaultLayout title="Past accessibility events">
   <div class="container grid">
     <div
-      id="events"
+      id="past-events"
       role="region"
       aria-labelledby="past-events-heading"
       class="py-l readable main-content"
@@ -31,7 +31,12 @@ Astro.response.headers.set(
         <StaticEventList type="past" />
       </noscript>
     </div>
-    <MonthNav id="month-nav" class="mb-l" client:idle contentRegion="#events" />
+    <MonthNav
+      id="month-nav"
+      class="mb-l"
+      client:idle
+      contentRegion="#past-events"
+    />
   </div>
   <!-- End container -->
 </DefaultLayout>

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -189,7 +189,7 @@ test.describe('Past Events page accessibility', () => {
   });
 
   test('events region is labelled', async ({ page }) => {
-    const region = page.locator('#events[role="region"]');
+    const region = page.locator('#past-events[role="region"]');
     await expect(region).toHaveAttribute(
       'aria-labelledby',
       'past-events-heading'


### PR DESCRIPTION
## Summary

- Both `index.astro` and `past-events.astro` used `id="events"` on their event container `<div>`, but E2E tests referenced `#upcoming-events` and `#past-events` — causing every test depending on those selectors to time out.
- Changed to page-specific IDs (`upcoming-events` / `past-events`) that are more descriptive and match the test expectations.
- Updated the `MonthNav` `contentRegion` prop and one accessibility test selector to match.

Fixes #548