### PR TITLE
Hide theme selector dropdown until custom element upgrades

### DIFF
--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -85,8 +85,10 @@
   outline-color: var(--c-focus-ring-color);
 }
 
-/* Hide theme-selector dropdown content until the custom element upgrades,
-   preventing a FOUC where menu items appear as a horizontal text list. */
+/* Hide theme-selector dropdown until the custom element upgrades,
+   preventing a FOUC where menu items appear as a horizontal text list.
+   display:none avoids reserving space for the unstyled text content;
+   margin-left:auto on .masthead__actions keeps the nav pinned right. */
 #theme-selector:not(:defined) {
-  visibility: hidden;
+  display: none;
 }

--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -34,6 +34,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--p-space-xs);
+  margin-left: auto;
 }
 
 .masthead .logo {

--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -83,3 +83,9 @@
 .masthead wa-button::part(base):focus-visible {
   outline-color: var(--c-focus-ring-color);
 }
+
+/* Hide theme-selector dropdown content until the custom element upgrades,
+   preventing a FOUC where menu items appear as a horizontal text list. */
+#theme-selector:not(:defined) {
+  visibility: hidden;
+}


### PR DESCRIPTION
## Summary

- The `wa-dropdown` theme selector in the header flashes its menu items ("Light mode", "Dark mode", "System default") as a horizontal text list before the custom element upgrades.
- Adds a targeted `#theme-selector:not(:defined) { visibility: hidden }` rule to hide the content until the component is ready.
- Uses `visibility: hidden` (not `display: none`) to preserve layout space and avoid a shift when it appears.

This is scoped to the one component — not a blanket `:not(:defined)` rule.