### PR TITLE
Make freshness check schema-aware and validate suggestions

### DIFF
--- a/scripts/check-event-freshness.mjs
+++ b/scripts/check-event-freshness.mjs
@@ -15,6 +15,9 @@
  *   SANITY_PROJECT     Sanity project ID (required)
  *   SANITY_DATASET     Sanity dataset name (defaults to "production")
  *   ANTHROPIC_API_KEY  Anthropic API key for Claude analysis (required)
+ *   FRESHNESS_MODEL    Override the Claude model ID (defaults to
+ *                      claude-sonnet-4-5-20250929; set to e.g.
+ *                      claude-haiku-4-5-20251001 for cheaper runs)
  *   GH_TOKEN           GitHub token for creating issues (required unless --dry-run)
  */
 
@@ -22,9 +25,11 @@ import { createClient } from '@sanity/client';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 import timezone from 'dayjs/plugin/timezone.js';
+import customParseFormat from 'dayjs/plugin/customParseFormat.js';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+dayjs.extend(customParseFormat);
 
 const projectId = process.env.SANITY_PROJECT;
 const dataset = process.env.SANITY_DATASET || 'production';
@@ -47,6 +52,182 @@ const sanity = createClient({
   apiVersion: '2024-01-01',
   useCdn: true,
 });
+
+// ---------------------------------------------------------------------------
+// Schema constraints
+//
+// Mirrors the Sanity event schema (eventua11y-sanity/schemas/event.js).
+// Used to validate Claude's suggestions deterministically before they are
+// surfaced to humans, so we never recommend values the schema can't store
+// or changes to fields that are hidden for the event's type.
+//
+// Keep in sync with the Studio schema. If the schema changes, update here.
+// ---------------------------------------------------------------------------
+
+const FIELD_TYPES = {
+  dateStart: 'datetime',
+  dateEnd: 'datetime',
+  callForSpeakers: 'boolean',
+  callForSpeakersClosingDate: 'datetime',
+  attendanceMode: 'enum',
+  location: 'string',
+  eventStatus: 'enum',
+};
+
+const FIELD_ENUMS = {
+  attendanceMode: ['online', 'offline', 'mixed', 'none'],
+  eventStatus: ['scheduled', 'cancelled', 'postponed', 'rescheduled'],
+};
+
+// Fields that the schema hides for `type === 'theme'` events. Suggesting
+// values for these is meaningless because the field is never shown in the
+// Studio and frontend consumers ignore it.
+const HIDDEN_FOR_THEME = new Set([
+  'callForSpeakers',
+  'callForSpeakersClosingDate',
+  'attendanceMode',
+]);
+
+// Phrases in a `reason` that indicate the model has talked itself out of
+// the suggestion. Treated as evidence to drop the row entirely.
+const SELF_CANCELLING_PHRASES = [
+  'no change',
+  'requires no change',
+  'is consistent',
+  'is actually consistent',
+  'matches the website',
+  'already matches',
+  'already correct',
+];
+
+/**
+ * Decide whether a single suggested change should be kept.
+ * Returns { keep: boolean, drop?: string } where `drop` explains why.
+ *
+ * Rules:
+ *  1. Drop if the field is hidden for this event's type.
+ *  2. Drop if the suggested value isn't representable in the schema.
+ *  3. Drop if current and suggested are equivalent (datetime instants
+ *     match, booleans/enums match literally).
+ *  4. Drop if the reason text contradicts the suggestion.
+ */
+function validateChange(change, event) {
+  const { field, current, suggested, reason } = change;
+
+  if (!field) return { keep: false, drop: 'missing field name' };
+
+  // Rule 1: hidden for theme events
+  if (event.type === 'theme' && HIDDEN_FOR_THEME.has(field)) {
+    return {
+      keep: false,
+      drop: `${field} is hidden for theme-type events`,
+    };
+  }
+
+  const type = FIELD_TYPES[field];
+
+  // Rule 2: representability
+  if (type === 'boolean') {
+    const s = String(suggested).toLowerCase().trim();
+    if (s !== 'true' && s !== 'false') {
+      return {
+        keep: false,
+        drop: `${field} is boolean; suggested "${suggested}" is not true/false`,
+      };
+    }
+  }
+
+  if (type === 'enum') {
+    const allowed = FIELD_ENUMS[field] || [];
+    const s = String(suggested).toLowerCase().trim();
+    if (!allowed.includes(s)) {
+      return {
+        keep: false,
+        drop: `${field} must be one of ${allowed.join('|')}; suggested "${suggested}"`,
+      };
+    }
+  }
+
+  if (type === 'datetime') {
+    // The suggested value is allowed to be a date string the model
+    // extracted from the website (e.g. "31 May 2026"). Reject only if
+    // it's literally "unknown" or "time unknown" — these can't be stored.
+    const s = String(suggested).toLowerCase().trim();
+    if (s === 'unknown' || s.includes('time unknown') || s === 'not set') {
+      return {
+        keep: false,
+        drop: `${field} is datetime; cannot store "${suggested}"`,
+      };
+    }
+  }
+
+  // Rule 3: equivalence
+  if (type === 'datetime' && current && suggested) {
+    // Parse the suggested string against a small set of human-readable
+    // date formats the prompt encourages. We compare calendar days in
+    // the event's timezone, not instants, because the model rarely
+    // includes a time component for date-only sources.
+    const tz = event.timezone || 'UTC';
+    const formats = [
+      'D MMMM YYYY',
+      'DD MMMM YYYY',
+      'D MMM YYYY',
+      'DD MMM YYYY',
+      'YYYY-MM-DD',
+      'MMMM D, YYYY',
+      'MMMM D YYYY',
+    ];
+    const suggestedDay = dayjs(String(suggested), formats, true);
+    const currentDay = event[field] ? dayjs.utc(event[field]).tz(tz) : null;
+    if (
+      suggestedDay.isValid() &&
+      currentDay &&
+      suggestedDay.format('YYYY-MM-DD') === currentDay.format('YYYY-MM-DD')
+    ) {
+      // Same calendar day -- treat as equivalent unless the suggestion
+      // explicitly carries a different time component.
+      const reasonHasTimeChange = /\b\d{1,2}:\d{2}\b/.test(String(suggested));
+      if (!reasonHasTimeChange) {
+        return {
+          keep: false,
+          drop: `${field} suggested value resolves to same date as current`,
+        };
+      }
+    }
+  }
+
+  if (type === 'boolean' || type === 'enum') {
+    const c = String(current).toLowerCase().trim();
+    const s = String(suggested).toLowerCase().trim();
+    // Map the prompt's "yes"/"no"/"not set" prose for booleans so we
+    // can detect equivalence with the canonical true/false value.
+    const norm = (v) => {
+      if (v === 'yes') return 'true';
+      if (v === 'no') return 'false';
+      if (v === 'not set' || v === 'null' || v === '') return '';
+      return v;
+    };
+    if (norm(c) === norm(s)) {
+      return {
+        keep: false,
+        drop: `${field} current and suggested are equivalent (${suggested})`,
+      };
+    }
+  }
+
+  // Rule 4: self-cancelling reason text
+  const r = String(reason || '').toLowerCase();
+  for (const phrase of SELF_CANCELLING_PHRASES) {
+    if (r.includes(phrase)) {
+      return {
+        keep: false,
+        drop: `reason indicates no change needed ("${phrase}")`,
+      };
+    }
+  }
+
+  return { keep: true };
+}
 
 // ---------------------------------------------------------------------------
 // Sanity: fetch upcoming events with websites
@@ -189,22 +370,35 @@ async function analyseWithClaude(event, pageText) {
     ? ` (${event.timezone})`
     : ' (international event, no specific timezone)';
 
-  const eventSummary = [
+  // Render values in their stored form so the model sees -- and the report
+  // surfaces -- literal database values, not English prose. This avoids the
+  // "yes -> false" confusion where the model thinks they differ.
+  const isTheme = event.type === 'theme';
+  const summaryLines = [
     `Title: ${event.title}`,
-    `Start: ${startStr}${tzNote}`,
-    `End: ${endStr}${tzNote}`,
     `Type: ${event.type}`,
-    `Status in our database: ${event.eventStatus || 'scheduled (default)'}`,
-    `Attendance mode: ${event.attendanceMode || 'not set'}`,
-    `Location: ${event.location || 'not set'}`,
-    `Call for speakers: ${event.callForSpeakers === true ? 'yes' : event.callForSpeakers === false ? 'no' : 'not set'}`,
-    event.callForSpeakersClosingDate
-      ? `CFS closing date: ${dayjs.utc(event.callForSpeakersClosingDate).tz(tz).format('D MMMM YYYY [at] HH:mm')}${tzNote}`
-      : null,
-    `Is parent event (conference with sessions): ${event.isParent ? 'yes' : 'no'}`,
-  ]
-    .filter(Boolean)
-    .join('\n');
+    `dateStart (datetime): ${startStr}${tzNote}`,
+    `dateEnd (datetime): ${endStr}${tzNote}`,
+    `eventStatus (enum): ${event.eventStatus || 'scheduled (default)'}`,
+    `Is parent event (conference with sessions): ${event.isParent ? 'true' : 'false'}`,
+  ];
+  if (!isTheme) {
+    summaryLines.push(
+      `attendanceMode (enum): ${event.attendanceMode ?? 'null'}`,
+      `location (string): ${event.location ?? 'null'}`,
+      `callForSpeakers (boolean): ${event.callForSpeakers === true ? 'true' : event.callForSpeakers === false ? 'false' : 'null'}`
+    );
+    if (event.callForSpeakersClosingDate) {
+      summaryLines.push(
+        `callForSpeakersClosingDate (datetime): ${dayjs.utc(event.callForSpeakersClosingDate).tz(tz).format('D MMMM YYYY [at] HH:mm')}${tzNote} (UTC: ${event.callForSpeakersClosingDate})`
+      );
+    }
+  }
+  const eventSummary = summaryLines.join('\n');
+
+  const themeFieldNote = isTheme
+    ? `\n\nIMPORTANT: This is a theme/awareness-day event (type === "theme"). The fields callForSpeakers, callForSpeakersClosingDate, and attendanceMode are HIDDEN in the CMS for theme events and must not appear in your "changes". Do not suggest values for them under any circumstances.`
+    : '';
 
   const prompt = `You are helping maintain a curated calendar of accessibility and inclusive design events. Compare the following event record from our database against the text extracted from the event's official website.
 
@@ -218,42 +412,64 @@ ${pageText}
 
 ## Your task
 
-Analyse the website text and identify any fields in our database that need updating. Focus on:
+Identify fields in the database that need updating. Focus on:
 
-1. **Dates**: The dates above are already in the event's local timezone, so compare them directly against what the website shows. Be careful to distinguish actual event dates from other dates on the page (CFS deadlines, early-bird dates, blog post dates). Only flag if you are confident the website shows different event dates.
+1. **Dates (dateStart, dateEnd)**: The dates above are already in the event's local timezone, so compare them directly against what the website shows. Be careful to distinguish actual event dates from other dates on the page (CFS deadlines, early-bird dates, blog post dates). Only flag if you are confident the website shows different event dates.
 
-2. **Event status**: Any indication the event has been cancelled, postponed, rescheduled, or sold out (for this edition, not past ones).
+2. **eventStatus**: Any indication the event has been cancelled, postponed, or rescheduled (for this edition, not past ones). Sold-out is not a status change.
 
-3. **Call for speakers/proposals**: Is a CFS mentioned? Is it open, closed, or does it have a deadline? Compare with our record.
+3. **callForSpeakers / callForSpeakersClosingDate**: Is a CFS open or closed for THIS edition? Prefer dated announcements (news posts, blog entries) over static homepage hero copy, which may be stale. If the homepage says "soon" but a recent dated post announces the CFS is open, trust the dated post.
 
-4. **Location**: Has the venue or city changed?
+4. **location**: Has the venue or city changed?
 
-5. **Other**: Anything else that needs updating (renamed, placeholder page, content mismatch).
+5. **attendanceMode**: Has the format (online/offline/mixed) changed?
 
-Respond with ONLY a JSON object (no markdown fences) in this exact format:
+6. **Other**: Anything else worth noting (renamed, placeholder page, content mismatch). Put these in "notes", not "changes".${themeFieldNote}
+
+## Schema constraints (HARD rules — violations will be discarded)
+
+Each field has a fixed type and value space. Only suggest values that fit:
+
+- \`callForSpeakers\` (boolean): "true" or "false". There is NO "unknown" value — if you cannot tell, omit the change.
+- \`attendanceMode\` (enum): exactly one of "online", "offline", "mixed", "none". The word "multiple" is NOT valid; use "mixed".
+- \`eventStatus\` (enum): exactly one of "scheduled", "cancelled", "postponed", "rescheduled".
+- \`dateStart\`, \`dateEnd\`, \`callForSpeakersClosingDate\` (datetime): ISO datetime or a date string the website explicitly states (e.g. "31 May 2026", "9 June 2026"). NEVER suggest "unknown" or "time unknown" — these can't be stored. If the website doesn't state a time, suggest just the date and the value will be reconciled separately.
+
+## Equivalence and self-cancellation
+
+Before adding a change, ask yourself: does my "suggested" value actually differ from "current"? Examples that MUST NOT be reported as changes:
+
+- Current "15:30" and suggested "3:30 PM" — same instant in 24h vs 12h notation.
+- Current "10 June 2026 at 00:59 (Europe/London)" and website says "9 June 2026" in a US timezone — these may be the same UTC instant. If unsure, omit the change.
+- Current "false" and suggested "no" — same boolean.
+
+If your "reason" text concludes the values match, are consistent, or no change is needed, OMIT the change entirely. Do not emit a row only to explain why it isn't really a change.
+
+## Response format
+
+Respond with ONLY a JSON object (no markdown fences) in this exact shape:
+
 {
   "changes": [
     {
-      "field": "dateStart|dateEnd|eventStatus|callForSpeakers|callForSpeakersClosingDate|location|attendanceMode|other",
+      "field": "dateStart|dateEnd|eventStatus|callForSpeakers|callForSpeakersClosingDate|location|attendanceMode",
       "severity": "warning|info",
-      "current": "What our database currently has for this field",
-      "suggested": "What the website suggests it should be, or 'unknown' if unclear",
-      "reason": "One sentence explaining the evidence from the website"
+      "current": "Literal current value as shown in the database record above",
+      "suggested": "Schema-valid replacement value (see constraints above)",
+      "reason": "One sentence citing the specific website text that justifies the change"
     }
   ],
   "noChanges": true|false,
-  "notes": "Optional one-sentence note about anything worth mentioning that does not require a database change, or null"
+  "notes": "Optional one-sentence note about something worth mentioning that does not fit a structured change, or null"
 }
 
 Rules:
-- Set "noChanges" to true and return an empty "changes" array if everything looks consistent.
-- Use "warning" severity for changes that likely need a database update.
-- Use "info" severity for things worth flagging but that may not need action.
-- For date fields, use the format the website shows (e.g. "23 June 2026") in the "suggested" value.
-- For boolean fields (callForSpeakers, isParent), use "true" or "false" as strings in "suggested".
-- Be conservative: only flag genuine discrepancies, not ambiguities.
-- Do not invent changes. If the page is unclear, say so in "notes" instead.
-- NEVER suggest changing isParent. This is an editorial decision about how we curate events, not something that can be inferred from a website. Events dedicated to accessibility (like CSUN, AccessU, Inclusive Design 24) are listed as standalone events, not parent events with children. Only broad multi-topic conferences that happen to include some accessibility content (like UX London, Figma Config) are marked as parent events so we can list their individual accessibility-relevant sessions.`;
+- Set "noChanges": true and an empty "changes" array if everything looks consistent.
+- "warning" severity = clear discrepancy needing a database update. "info" = ambiguous, worth a human glance.
+- Be conservative. When in doubt, use "notes" instead of "changes".
+- Never suggest changing isParent. This is an editorial decision about how we curate events, not something that can be inferred from a website. Events dedicated to accessibility (CSUN, AccessU, Inclusive Design 24) are standalone events. Only broad multi-topic conferences with embedded accessibility sessions (UX London, Figma Config) are marked as parent events.`;
+
+  const model = process.env.FRESHNESS_MODEL || 'claude-sonnet-4-5-20250929';
 
   const response = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
@@ -263,7 +479,7 @@ Rules:
       'anthropic-version': '2023-06-01',
     },
     body: JSON.stringify({
-      model: 'claude-haiku-4-5-20251001',
+      model,
       max_tokens: 1024,
       messages: [{ role: 'user', content: prompt }],
     }),
@@ -364,6 +580,34 @@ async function checkEvent(event) {
   }
 
   const analysis = await analyseWithClaude(event, plainText);
+
+  // Validate every suggested change against the schema. The model's
+  // instructions cover this, but we double-check deterministically so a
+  // single bad model response can't introduce noisy or invalid suggestions.
+  const dropped = [];
+  if (analysis.changes && analysis.changes.length > 0) {
+    const kept = [];
+    for (const change of analysis.changes) {
+      const verdict = validateChange(change, event);
+      if (verdict.keep) {
+        kept.push(change);
+      } else {
+        dropped.push({ change, reason: verdict.drop });
+      }
+    }
+    analysis.changes = kept;
+    if (kept.length === 0 && (!analysis.notes || analysis.notes === null)) {
+      analysis.noChanges = true;
+    }
+  }
+
+  if (dropped.length > 0) {
+    // Surface drops at debug verbosity so failures are diagnosable without
+    // polluting the human-facing report.
+    for (const { change, reason } of dropped) {
+      console.warn(`  Dropped suggestion (${change.field || '?'}): ${reason}`);
+    }
+  }
 
   if (analysis.changes && analysis.changes.length > 0) {
     for (const change of analysis.changes) {


### PR DESCRIPTION
Closes #698. Validates and ships fixes for every failure mode observed in #694.

## Problem

The freshness check has been emitting recommendations that don't survive validation. From #698 / verification of #694: 0 of 12 suggestions were valid.

Failure modes:
1. Suggested values the schema can't store (`callForSpeakers: "unknown"`, `attendanceMode: "multiple"`, `dateStart: "time unknown"`).
2. Suggested changes to fields the schema hides for `type === "theme"` events.
3. Flagged timezone-shifted display strings as differences (`15:30` vs `3:30 PM`; `9 June UTC` vs `10 June Europe/London`).
4. Read only the homepage hero, missing dated CFS announcements on news pages (ID24, WPAD).
5. Emitted self-contradicting rows whose reason concluded "no change required".
6. Rendered booleans as prose `yes`/`no` so `no → false` looked like a real change.

## Approach

Two layers of defence: prompt + deterministic post-filter. The prompt change alone is unreliable (the model previously followed bad instructions exactly as told); the post-filter guarantees no schema-invalid or self-cancelling suggestion reaches the report.

### 1. Schema constants in-file

`FIELD_TYPES`, `FIELD_ENUMS`, `HIDDEN_FOR_THEME` mirror `eventua11y-sanity/schemas/event.js`. Kept in-script (rather than introspected at runtime) because the schema is small and stable, and avoids a second Sanity round-trip per run. Comment notes the sync requirement.

### 2. `validateChange(change, event)` post-filter

Runs on every model suggestion and drops it if:
- The field is in `HIDDEN_FOR_THEME` and `event.type === 'theme'`.
- A boolean suggestion isn't `true`/`false`.
- An enum suggestion isn't in the allowed list.
- A datetime suggestion is `"unknown"` / `"time unknown"` / `"not set"`.
- A datetime suggestion parses (via `customParseFormat`) to the same calendar day as the current value in the event's timezone, and no time component differs.
- A boolean/enum suggestion is literally equivalent to current after normalising `yes`→`true` etc.
- The reason text contains a self-cancelling phrase (`no change`, `is consistent`, `already correct`, etc.).

Drops are logged at warn-level so failures are diagnosable but don't pollute the human-facing report.

### 3. Prompt tightening

- Spells out the schema constraints inline as "HARD rules — violations will be discarded".
- Adds an "Equivalence and self-cancellation" section with worked examples from #694.
- Adds a theme-event note conditionally injected when `event.type === 'theme'`.
- Encourages preferring dated announcements over static hero copy.
- Renders the database record in stored form (`true`/`false`, ISO datetimes, enum literals) so the model isn't comparing apples to prose.

### 4. Model: Sonnet 4.5 (was Haiku 4.5)

Three of the failure modes (judgement on source recency, internal consistency between reason and suggestion, equivalence reasoning across timezones) benefit from Sonnet's stronger reasoning. Cost delta is negligible at ~14 events weekly = cents per run. Configurable via `FRESHNESS_MODEL` env var if you ever want to revert or experiment.

## Validation

Wrote a temporary harness (not committed; the script doesn't export `validateChange` and adding an export felt out of scope) that loaded the function via `Function` constructor and ran 14 cases covering every #694 failure plus 3 genuine changes that should still pass through:

```
PASS  [#694 ID24] callForSpeakers true->false (genuine)
PASS  [#694 WPAD] callForSpeakers true->unknown
PASS  [#694 GAAD] attendanceMode null->multiple (theme)
PASS  [GAAD] attendanceMode null->mixed (non-theme hypothetical)
PASS  [#694 GAAD] attendanceMode null->multiple (non-theme, bad enum)
PASS  [#694 AccessU] dateEnd 15:30 -> 3:30 PM, reason says no change
PASS  [#694 UX London] dateStart -> time unknown
PASS  [#694 CSS Day] callForSpeakers no -> false (equivalent)
PASS  [#694 Agile Testing] callForSpeakers false -> unknown
PASS  [#694 UKDHM] dateEnd 19 Dec -> 19 December 2026 (same day)
PASS  [#694 ID24] CFS closing date drop time (date-only same day)
PASS  GENUINE: dateEnd 19 Dec -> 20 Dec
PASS  GENUINE: eventStatus scheduled -> cancelled
PASS  GENUINE: dateStart shifts to a different time

14/14 passed
```

Also ran `node --check` and `npx prettier --write`.

## What's not in this PR

- **Crawling one level deep** for CFS news pages (failure mode 4, partially). Sonnet's better judgement on dated vs static copy mitigates this; doing it properly needs a sub-fetcher and rate-limit care, which is a bigger change. The prompt now explicitly tells the model to prefer dated announcements.
- **Schema introspection from Sanity at runtime.** Considered and rejected — the constants are small, stable, and one comment-line away from being kept in sync. Worth revisiting if the schema starts changing often.
- **A test file.** The script has no existing test setup and adding vitest scaffolding for one helper feels disproportionate. Open to adding it if maintainers prefer.

## Acceptance criteria from #698

- [x] Suggestions constrained to schema-valid values
- [x] Hidden-field rules respected
- [x] No suggestion when current and proposed are semantically equivalent (timezone-normalised for datetimes; literal for booleans/enums)
- [x] CFS status checks consult dated news pages — addressed via prompt + Sonnet upgrade; not via deeper crawling
- [x] Self-contradicting rows suppressed
- [x] Current/suggested values rendered in stored form