### PR TITLE
Fix past-dated suggestions and malformed table rendering in freshness check

### DIFF
--- a/scripts/check-event-freshness.mjs
+++ b/scripts/check-event-freshness.mjs
@@ -682,8 +682,12 @@ function formatFindings(findings) {
     lines.push(`- ${f}`);
   }
 
-  // Structured changes as a table
+  // Structured changes as a table. GitHub Markdown requires a blank
+  // line before a table when it directly follows a list, otherwise
+  // the table is treated as a continuation of the list and rendered
+  // as one mashed-up line.
   if (changes.length > 0) {
+    if (lines.length > 0) lines.push('');
     lines.push('| Field | Current | Suggested | Reason |');
     lines.push('| --- | --- | --- | --- |');
     for (const c of changes) {
@@ -694,9 +698,13 @@ function formatFindings(findings) {
     }
   }
 
-  // Notes
-  for (const n of notes) {
-    lines.push(`> ${n.note}`);
+  // Notes (also need a blank line above to render as a separate
+  // blockquote rather than getting absorbed into the previous block).
+  if (notes.length > 0) {
+    if (lines.length > 0) lines.push('');
+    for (const n of notes) {
+      lines.push(`> ${n.note}`);
+    }
   }
 
   return lines;

--- a/scripts/check-event-freshness.mjs
+++ b/scripts/check-event-freshness.mjs
@@ -226,6 +226,33 @@ function validateChange(change, event) {
     }
   }
 
+  // Rule 5: past-dated datetime suggestions for upcoming events
+  //
+  // The freshness check only runs against events whose dateEnd is in
+  // the future, so a suggestion that resolves to a past date is almost
+  // always a confused reading of a website that hasn't been updated for
+  // the new edition yet (e.g. DAW 2026 record vs. site still showing
+  // DAW 2025 wrap-up text). Those need a human eye, not a structured
+  // change. Surface as a note instead by dropping the change here.
+  if (type === 'datetime') {
+    const formats = [
+      'D MMMM YYYY',
+      'DD MMMM YYYY',
+      'D MMM YYYY',
+      'DD MMM YYYY',
+      'YYYY-MM-DD',
+      'MMMM D, YYYY',
+      'MMMM D YYYY',
+    ];
+    const suggestedDay = dayjs(String(suggested), formats, true);
+    if (suggestedDay.isValid() && suggestedDay.isBefore(dayjs(), 'day')) {
+      return {
+        keep: false,
+        drop: `${field} suggested value (${suggested}) is in the past; likely website still shows previous edition`,
+      };
+    }
+  }
+
   return { keep: true };
 }
 
@@ -444,6 +471,10 @@ Before adding a change, ask yourself: does my "suggested" value actually differ 
 - Current "false" and suggested "no" — same boolean.
 
 If your "reason" text concludes the values match, are consistent, or no change is needed, OMIT the change entirely. Do not emit a row only to explain why it isn't really a change.
+
+## Stale website content
+
+This check only runs against events whose end date is in the future. If the website still describes a past edition (e.g. "Thank you for joining us at FooConf 2025" while our record is FooConf 2026), DO NOT suggest changing the database dates back to the past edition. The site is likely stale, not the database. Put the observation in "notes" so a human can chase the organiser.
 
 ## Response format
 


### PR DESCRIPTION
Two small follow-ups to #699 / #698 catching things that surfaced in #700.

## 1. Drop past-dated suggestions

The 25 April run (#700) for Dyslexia Awareness Week proposed:

> `dateStart`: Monday, 5 October 2026 → Monday, **6 October 2025**
> `dateEnd`: Sunday, 11 October 2026 → Sunday, **12 October 2025**

The model's reasoning was correct (the BDA site still describes DAW 2025), but the suggestion is nonsensical: rolling a future event's dates back into the past. This is exactly the kind of regression a freshness checker should never recommend.

The post-filter from #699 didn't catch it because the suggestion is a parseable datetime that isn't equivalent to the current value.

**Fix:** adds **Rule 5** to `validateChange` — drop any datetime suggestion whose parsed value is `before(dayjs(), 'day')`. Safe because the upstream Sanity query already filters to `dateEnd >= now()`, so a past-dated suggestion can only mean the website hasn't been updated for the new edition yet.

Also tightens the prompt with a "Stale website content" section that tells the model to put observations like "site still shows last year's wrap-up" in `notes`, not `changes`. Belt-and-braces.

## 2. Fix malformed Markdown rendering

Issue #700's UX London 2026 entry ran the "Website redirected to subdomain" bullet straight into the changes table, collapsing the whole table into a single mashed-up line on GitHub. GitHub-flavoured Markdown needs a blank line before a table when it follows a list (and before a blockquote when it follows a table); the formatter wasn't inserting them.

**Fix:** insert blank separators between sections in `formatFindings`.

## Validation

Re-ran the harness from PR #699 with two new #700 cases added:

```
PASS  [#700 DAW] dateStart 5 Oct 2026 -> 6 October 2025 (past)
PASS  [#700 DAW] dateEnd 11 Oct 2026 -> 12 October 2025 (past)
PASS  [#700 All Day Hey] callForSpeakers null -> false (genuine, kept)
PASS  [#700 UX London] callForSpeakers true -> false (genuine, kept)

18/18 passed
```

The All Day Hey / UX London suggestions from #700 were good signal and have already been applied to Sanity.

## Run quality after this patch

Of #700's 4 reports:
- All Day Hey ✅ valid (applied)
- UX London ✅ valid (applied)
- Dyslexia Awareness Week ❌ → would now be dropped from `changes` and surface only as a note
- All Things Open ⚠️ HTTP 403, not a model issue

Net: every model-generated suggestion would now be either correct or suppressed, and the report would render correctly.