### PR TITLE
Strip weekday prefix when parsing suggested dates

### DIFF
--- a/scripts/check-event-freshness.mjs
+++ b/scripts/check-event-freshness.mjs
@@ -88,6 +88,32 @@ const HIDDEN_FOR_THEME = new Set([
   'attendanceMode',
 ]);
 
+// Date formats accepted by the strict dayjs parser used in Rules 3 and 5.
+// dayjs's customParseFormat plugin can't parse the `dddd` (weekday name)
+// token even non-strictly, so any leading "Monday, " etc. is stripped by
+// `parseSuggestedDate` before the value reaches the formats list. The
+// list still has to cover everything the prompt tells the model to emit
+// (`D MMMM YYYY` / `D MMMM YYYY [at] HH:mm`), plus a few common variants.
+const SUGGESTED_DATE_FORMATS = [
+  'D MMMM YYYY',
+  'D MMMM YYYY [at] HH:mm',
+  'D MMMM YYYY HH:mm',
+  'DD MMMM YYYY',
+  'D MMM YYYY',
+  'DD MMM YYYY',
+  'YYYY-MM-DD',
+  'MMMM D, YYYY',
+  'MMMM D YYYY',
+];
+
+// Parse a suggested datetime string from the model. Strips a leading
+// weekday name ("Monday, ", "Tue, ") before delegating to dayjs because
+// `customParseFormat` can't handle the `dddd`/`ddd` tokens.
+function parseSuggestedDate(value) {
+  const cleaned = String(value).replace(/^[A-Za-z]+,\s*/, '');
+  return dayjs(cleaned, SUGGESTED_DATE_FORMATS, true);
+}
+
 // Phrases in a `reason` that indicate the model has talked itself out of
 // the suggestion. Treated as evidence to drop the row entirely.
 const SELF_CANCELLING_PHRASES = [
@@ -168,16 +194,7 @@ function validateChange(change, event) {
     // the event's timezone, not instants, because the model rarely
     // includes a time component for date-only sources.
     const tz = event.timezone || 'UTC';
-    const formats = [
-      'D MMMM YYYY',
-      'DD MMMM YYYY',
-      'D MMM YYYY',
-      'DD MMM YYYY',
-      'YYYY-MM-DD',
-      'MMMM D, YYYY',
-      'MMMM D YYYY',
-    ];
-    const suggestedDay = dayjs(String(suggested), formats, true);
+    const suggestedDay = parseSuggestedDate(suggested);
     const currentDay = event[field] ? dayjs.utc(event[field]).tz(tz) : null;
     if (
       suggestedDay.isValid() &&
@@ -235,16 +252,7 @@ function validateChange(change, event) {
   // DAW 2025 wrap-up text). Those need a human eye, not a structured
   // change. Surface as a note instead by dropping the change here.
   if (type === 'datetime') {
-    const formats = [
-      'D MMMM YYYY',
-      'DD MMMM YYYY',
-      'D MMM YYYY',
-      'DD MMM YYYY',
-      'YYYY-MM-DD',
-      'MMMM D, YYYY',
-      'MMMM D YYYY',
-    ];
-    const suggestedDay = dayjs(String(suggested), formats, true);
+    const suggestedDay = parseSuggestedDate(suggested);
     if (suggestedDay.isValid() && suggestedDay.isBefore(dayjs(), 'day')) {
       return {
         keep: false,


### PR DESCRIPTION
## Summary
- Rules 3 (equivalence) and 5 (past-date drop) parse the model's suggested datetime strings with `dayjs` strict mode, but the prompt asks the model to format dates as `dddd, D MMMM YYYY` (e.g. `Monday, 6 October 2025`). `customParseFormat` can't handle the `dddd` token, so every suggestion came back invalid and the past-date guard silently did nothing.
- This is what let issue #702 publish change rows for Dyslexia Awareness Week proposing 2025 dates for an event in late 2026, even though the model itself flagged the suspicion in its `note`.
- Fix: strip a leading weekday (`/^[A-Za-z]+,\s*/`) before parsing, and centralise the formats list in a single `SUGGESTED_DATE_FORMATS` constant shared by both rules. No prompt changes -- the model's preferred output format keeps working, we just stop choking on it.

## Verification
Verified the parser against the DAW failure case and a regression set:

| Suggested value | Parses? | Detected as past? |
| --- | --- | --- |
| `Monday, 6 October 2025` | yes | yes |
| `Sunday, 12 October 2025` | yes | yes |
| `Monday, 5 October 2026` | yes | no |
| `Tuesday, 31 May 2026 at 09:00` | yes | no |
| `6 October 2025` | yes | yes |
| `2025-10-06` | yes | yes |
| `October 6, 2025` | yes | yes |
| `nonsense string` | no | n/a |

Refs #702.