### PR TITLE
chore(agents): extend lead bash allow-list with read-only commands

### DIFF
--- a/.agents/lead.md
+++ b/.agents/lead.md
@@ -13,7 +13,7 @@ Frontier (Claude Opus). Orchestration, cross-domain planning, and pre-merge revi
 - Read-only file access for context gathering
 - Task delegation to all other agents
 - No file editing
-- Read-only bash allow-list (git status/diff/log/branch/show, gh issue/pr view/list, gh api, npm ls/view/audit) for inspection
+- Read-only bash allow-list (git status/diff/log/branch/show/add, gh issue/pr view/list/checks/status, gh workflow view/list, gh api, npm ls/view/audit) for inspection
 - All other shell commands require user approval
 
 ## Escalation

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Flagsmith Server-side SDK Token for local evaluation mode.
+# Generate per-environment in the Flagsmith UI: Environment settings →
+# SDK keys → "Server-side SDK Token". This is NOT the same as the
+# "Environment API key" — local evaluation requires the server-side type.
+# Optional locally — if absent, flags fall back to defaults.
+# Required in Netlify production and deploy-preview scopes.
+FLAGSMITH_ENVIRONMENT_KEY=
+
+# Sentry source map upload. Optional locally.
+SENTRY_AUTH_TOKEN=
+
+# FontAwesome kit code (used by src/layouts/default.astro).
+FA_KIT_CODE=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: '@openfeature/flagsmith-provider'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.opencode/agents/lead.md
+++ b/.opencode/agents/lead.md
@@ -23,6 +23,11 @@ permission:
     'gh repo view*': allow
     'gh run list*': allow
     'gh run view*': allow
+    'gh pr checks*': allow
+    'gh pr status*': allow
+    'gh workflow list*': allow
+    'gh workflow view*': allow
+    'git add*': allow
     'npm ls*': allow
     'npm view*': allow
     'npm audit*': allow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,34 @@ This project uses a two-layer accessibility testing strategy in `tests/accessibi
 
 When adding new pages or interactive components, add both layers. For detailed testing patterns including shadow DOM caveats, dark mode scanning, and helper functions, see the `writing-a11y-tests` OpenCode skill in `.opencode/skills/writing-a11y-tests/SKILL.md`.
 
+## Feature Flags
+
+This project uses OpenFeature with the Flagsmith provider for server-side feature flag evaluation. See `src/lib/flags.ts`, `src/middleware/flags.ts`, and `src/types/flags.ts`.
+
+### Adding a new flag
+
+1. Add the flag name and JSDoc to the `Flags` interface in `src/types/flags.ts`.
+2. Add a default value (almost always `false`) to `FLAG_DEFAULTS`.
+3. Add a `client.getBooleanValue(...)` call in `resolveFlags()` in `src/lib/flags.ts`.
+4. Create the flag in all three Flagsmith environments (development, preview, production) with default value `false`.
+5. Read in SSR pages/components via `Astro.locals.flags.your_flag_name`.
+
+### Key type
+
+The `FLAGSMITH_ENVIRONMENT_KEY` env var holds a **Server-side SDK Token**, not an Environment API key. Local evaluation mode requires this key type. Generated per-environment in the Flagsmith UI under Environment settings → SDK keys. Each Netlify environment scope (production, deploy-preview) gets its own token.
+
+### Diagnostic
+
+The `<html>` element carries `data-flags-source="remote"` when the Flagsmith provider was reachable on a given request, or `data-flags-source="default"` when the middleware fell back to defaults. Use this to verify the provider is wired up in any environment.
+
+### Constraints
+
+- **Server-side only.** Do not import from `src/lib/flags.ts` in any client-side code or Vue island.
+- **Prerendered pages cannot read flags.** `Astro.locals.flags` is populated by middleware, which does not run for prerendered routes (404, accessibility, curation-policy). Flag-gated UI must not appear on prerendered pages.
+- **Vue islands receive flags as props.** Pass values from `Astro.locals.flags` as component props at render time.
+- **Propagation lag.** Flagsmith changes propagate to each warm Lambda instance within ~60s (local evaluation polling interval). Cold-started Lambdas fetch fresh data on init. Anonymous evaluation only — no user identity is passed to Flagsmith.
+- **Empty evaluation context.** All `getBooleanValue` calls pass `{}` explicitly. Do not pass user data — this is a regression-prevention guard.
+
 ## GROQ Query Projections
 
 Event listing queries in `src/lib/sanity.ts` and `netlify/edge-functions/get-events.ts` use **explicit field projections** — not the `...` spread operator. This is intentional to reduce payload sizes by excluding fields only needed on detail pages (e.g. `description`, `organizer`, `topics`, `geopoint`, `keywords`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Deployment**: Netlify with Deno-based edge functions
 - **Testing**: Playwright (E2E) + axe-core (accessibility) + Vitest (unit)
 - **Monitoring**: Sentry for error tracking and performance
+- **Feature flags**: OpenFeature with Flagsmith provider, server-side, local-evaluation mode (see Feature Flags section in `AGENTS.md`)
 - **Auth**: Supabase for user accounts (in progress)
 
 ### Key Files
@@ -51,6 +52,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `src/store/userStore.ts` — Vue reactive store for user preferences (theme, timezone)
 - `netlify/edge-functions/` — Three API endpoints (events, books, user-info)
 - `tests/accessibility.spec.ts` — Two-layer accessibility test suite
+- `src/lib/flags.ts`, `src/middleware/flags.ts`, `src/types/flags.ts` — OpenFeature/Flagsmith plumbing
 
 ### Content Types
 
@@ -73,6 +75,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `PLAYWRIGHT_TEST_BASE_URL`: Override test target URL (set by CI for deploy previews)
 - `PUBLIC_SUPABASE_URL`: Supabase project URL (client-safe)
 - `PUBLIC_SUPABASE_ANON_KEY`: Supabase publishable key (client-safe)
+- `FLAGSMITH_ENVIRONMENT_KEY`: Flagsmith Server-side SDK Token (server-only; optional locally)
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ See the [contributing guide](CONTRIBUTING.md) for ways to get involved in this p
 - [Netlify](https://www.netlify.com/) -- hosting with automatic deploys from the `main` branch. Feature branches are deployed to preview URLs.
 - [Sentry](https://sentry.io/) -- error tracking and performance monitoring
 
+### Feature flags
+
+- [OpenFeature](https://openfeature.dev/) with the [Flagsmith](https://www.flagsmith.com/) provider -- server-side feature flag evaluation in local-evaluation mode (no per-request HTTP). See the Feature Flags section in [AGENTS.md](AGENTS.md) for the flag-authoring workflow and constraints.
+
 ### Testing
 
 - [Playwright](https://playwright.dev/) -- end-to-end and accessibility tests
@@ -64,13 +68,14 @@ See the [contributing guide](CONTRIBUTING.md) for ways to get involved in this p
 
 The edge functions require the following environment variables, configured in Netlify:
 
-| Variable             | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `SANITY_PROJECT`     | Sanity project ID                                            |
-| `SANITY_DATASET`     | Sanity dataset name                                          |
-| `SANITY_API_VERSION` | Sanity API version                                           |
-| `SANITY_CDN`         | Whether to use the Sanity CDN (`true`/`false`)               |
-| `SENTRY_AUTH_TOKEN`  | Sentry auth token (used during build for source map uploads) |
+| Variable                    | Description                                                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `SANITY_PROJECT`            | Sanity project ID                                                                                                                    |
+| `SANITY_DATASET`            | Sanity dataset name                                                                                                                  |
+| `SANITY_API_VERSION`        | Sanity API version                                                                                                                   |
+| `SANITY_CDN`                | Whether to use the Sanity CDN (`true`/`false`)                                                                                       |
+| `SENTRY_AUTH_TOKEN`         | Sentry auth token (used during build for source map uploads)                                                                         |
+| `FLAGSMITH_ENVIRONMENT_KEY` | Flagsmith **Server-side SDK Token** for OpenFeature (one per Netlify scope; optional locally — flags fall back to defaults if unset) |
 
 ### Getting started
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,4 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig, envField } from 'astro/config';
 import { loadEnv } from 'vite';
 import netlify from '@astrojs/netlify';
 import vue from '@astrojs/vue';
@@ -12,6 +12,15 @@ const { SENTRY_AUTH_TOKEN } = loadEnv(process.env.NODE_ENV, process.cwd(), '');
 export default defineConfig({
   site: 'https://eventua11y.com',
   adapter: netlify(),
+  env: {
+    schema: {
+      FLAGSMITH_ENVIRONMENT_KEY: envField.string({
+        context: 'server',
+        access: 'secret',
+        optional: true,
+      }),
+    },
+  },
   server: {
     allowedHosts: ['.ts.net'],
   },

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,7 @@
   "entry": [
     "src/pages/**/*.{astro,ts}",
     "src/scripts/main.ts",
+    "src/middleware/index.ts",
     "netlify/edge-functions/*.ts",
     "scripts/*.mjs",
     "postcss.config.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@sentry/cli": "^3.3.5",
         "astro-portabletext": "^0.13.0",
         "dayjs": "^1.11.13",
+        "flagsmith-nodejs": "^8.1.0",
         "vue": "^3.5.25"
       },
       "devDependencies": {
@@ -2364,6 +2365,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
@@ -4026,6 +4051,88 @@
         "@openfeature/server-sdk": "^1.17.1",
         "flagsmith-nodejs": "^6.1.0"
       }
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/flagsmith-nodejs": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/flagsmith-nodejs/-/flagsmith-nodejs-6.2.0.tgz",
+      "integrity": "sha512-AQGCN/J1z7aGJOyyu4YRTbCEpYVHiqbzoySODEYdSVc+iNPqiPX9vOyeG2pZyGh4FLW7JLhkLdFEAjzG7tGaPg==",
+      "license": "MIT",
+      "dependencies": {
+        "pino": "^8.8.0",
+        "semver": "^7.3.7",
+        "undici-types": "^6.19.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/@openfeature/flagsmith-provider/node_modules/undici-types": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.25.0.tgz",
+      "integrity": "sha512-vOw74RVVYFtnooUkZPxsY1GuuNNupSrCcANIAaDekpZ/Dp1sBuLLl5n2UCKpzxgmOwD66S4Jj24MrhmcDG+0vw==",
+      "license": "MIT"
     },
     "node_modules/@openfeature/server-sdk": {
       "version": "1.21.0",
@@ -7264,7 +7371,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -13391,79 +13497,18 @@
       }
     },
     "node_modules/flagsmith-nodejs": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/flagsmith-nodejs/-/flagsmith-nodejs-6.2.0.tgz",
-      "integrity": "sha512-AQGCN/J1z7aGJOyyu4YRTbCEpYVHiqbzoySODEYdSVc+iNPqiPX9vOyeG2pZyGh4FLW7JLhkLdFEAjzG7tGaPg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/flagsmith-nodejs/-/flagsmith-nodejs-8.1.0.tgz",
+      "integrity": "sha512-9hyUUGEFFYfKqryFI2whXxTBwxHtKELc6U/WfBh6eF9CmRCD4Z99mILbm9eKNjqhYF8sJxsTlKjNloN2rtEEwg==",
       "license": "MIT",
       "dependencies": {
-        "pino": "^8.8.0",
+        "jsonpath-plus": "^10.4.0",
+        "pino": "^10",
         "semver": "^7.3.7",
         "undici-types": "^6.19.8"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/flagsmith-nodejs/node_modules/pino": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
-      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-std-serializers": "^6.0.0",
-        "process-warning": "^3.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "sonic-boom": "^3.7.0",
-        "thread-stream": "^2.6.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/flagsmith-nodejs/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^4.0.0",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/flagsmith-nodejs/node_modules/pino-std-serializers": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-      "license": "MIT"
-    },
-    "node_modules/flagsmith-nodejs/node_modules/process-warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-      "license": "MIT"
-    },
-    "node_modules/flagsmith-nodejs/node_modules/sonic-boom": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
-      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/flagsmith-nodejs/node_modules/thread-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
-      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
+        "node": ">=20"
       }
     },
     "node_modules/flagsmith-nodejs/node_modules/undici-types": {
@@ -15128,6 +15173,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -15190,6 +15244,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonpointer": {
@@ -24878,7 +24950,6 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
       "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
@@ -24901,7 +24972,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
       "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
@@ -24911,7 +24981,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pkg-types": {
@@ -25671,7 +25740,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
       "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -26831,7 +26899,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
       "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -27313,7 +27380,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
       "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@astrojs/netlify": "^7.0.4",
         "@astrojs/vue": "^6.0.1",
         "@awesome.me/webawesome": "^3.3.1",
+        "@openfeature/flagsmith-provider": "~0.1.2",
+        "@openfeature/server-sdk": "^1.21.0",
         "@sanity/client": "^7.20.0",
         "@sentry/astro": "^10.47.0",
         "@sentry/cli": "^3.3.5",
@@ -4006,6 +4008,35 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-C3ynxtPYhe5qVJgQIqCNxZXeRXo4t1Eo86uiROr8+sD6F2OjEJGIp6VOGxz+r6jkad2s8Br9BnUJOvskhai/3A==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/@openfeature/flagsmith-provider": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@openfeature/flagsmith-provider/-/flagsmith-provider-0.1.2.tgz",
+      "integrity": "sha512-goWSnz1GNGBsm4jepTs/59zVG+p8DKmU88tn7m+fqAE8WrVmybLa6h0mANLF7vwSUn4KzmkWJ93Bx0nMSfpskw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openfeature/server-sdk": "^1.17.1",
+        "flagsmith-nodejs": "^6.1.0"
+      }
+    },
+    "node_modules/@openfeature/server-sdk": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.21.0.tgz",
+      "integrity": "sha512-ZBVAiyMeN+dxurcXGJlvuOpYg9X7V923MVCI5dq/kE/5o8ys7MCOPhW44e4PS+XABHzSRTw44hcgWez93xwifw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@openfeature/core": "^1.10.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -10364,7 +10395,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -13102,6 +13132,15 @@
         "fast-decode-uri-component": "^1.0.1"
       }
     },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -13350,6 +13389,88 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flagsmith-nodejs": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/flagsmith-nodejs/-/flagsmith-nodejs-6.2.0.tgz",
+      "integrity": "sha512-AQGCN/J1z7aGJOyyu4YRTbCEpYVHiqbzoySODEYdSVc+iNPqiPX9vOyeG2pZyGh4FLW7JLhkLdFEAjzG7tGaPg==",
+      "license": "MIT",
+      "dependencies": {
+        "pino": "^8.8.0",
+        "semver": "^7.3.7",
+        "undici-types": "^6.19.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/flagsmith-nodejs/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/flagsmith-nodejs/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/flagsmith-nodejs/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
+    "node_modules/flagsmith-nodejs/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "node_modules/flagsmith-nodejs/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/flagsmith-nodejs/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/flagsmith-nodejs/node_modules/undici-types": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.25.0.tgz",
+      "integrity": "sha512-vOw74RVVYFtnooUkZPxsY1GuuNNupSrCcANIAaDekpZ/Dp1sBuLLl5n2UCKpzxgmOwD66S4Jj24MrhmcDG+0vw==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -24182,7 +24303,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -25639,7 +25759,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/quote-unquote": {
@@ -25759,7 +25878,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -26793,7 +26911,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "@astrojs/netlify": "^7.0.4",
     "@astrojs/vue": "^6.0.1",
     "@awesome.me/webawesome": "^3.3.1",
+    "@openfeature/flagsmith-provider": "~0.1.2",
+    "@openfeature/server-sdk": "^1.21.0",
     "@sanity/client": "^7.20.0",
     "@sentry/astro": "^10.47.0",
     "@sentry/cli": "^3.3.5",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@sentry/cli": "^3.3.5",
     "astro-portabletext": "^0.13.0",
     "dayjs": "^1.11.13",
+    "flagsmith-nodejs": "^8.1.0",
     "vue": "^3.5.25"
   }
 }

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -1,0 +1,32 @@
+import * as Sentry from '@sentry/astro';
+
+// Capture the key value at module load time (before any request).
+// Used only for scrubbing — never logged or exposed.
+const FLAGSMITH_KEY = process.env.FLAGSMITH_ENVIRONMENT_KEY;
+
+Sentry.init({
+  dsn: 'https://63a5e1fe7a29dc3df46923bd277aa87e@o4505086842437632.ingest.us.sentry.io/4508463077588992',
+
+  // Sample 10% of transactions for performance monitoring.
+  tracesSampleRate: 0.1,
+
+  beforeSend(event) {
+    // Drop any event whose serialised form contains the actual Flagsmith key
+    // value. Replace with a redaction marker rather than dropping the whole
+    // event so the error context is preserved.
+    if (!FLAGSMITH_KEY) return event;
+    try {
+      const serialised = JSON.stringify(event);
+      if (serialised.includes(FLAGSMITH_KEY)) {
+        const scrubbed = serialised.replaceAll(
+          FLAGSMITH_KEY,
+          '[FLAGSMITH_KEY_REDACTED]'
+        );
+        return JSON.parse(scrubbed);
+      }
+    } catch {
+      // If serialisation fails, return the event unmodified.
+    }
+    return event;
+  },
+});

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,21 @@
 /* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+declare namespace App {
+  interface Locals {
+    /**
+     * Feature flags resolved per-request from Flagsmith via OpenFeature.
+     * Always populated by middleware — never null.
+     * Use `import('./types/flags').Flags` form to avoid a top-of-file import
+     * that would conflict with PR #638's planned `User` import.
+     */
+    flags: import('./types/flags').Flags;
+
+    /**
+     * Indicates whether flags were resolved from the remote provider or fell
+     * back to defaults. Rendered as `data-flags-source` on the `<html>` element.
+     */
+    flagsSource: 'remote' | 'default';
+  }
+}

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -13,7 +13,11 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
 ---
 
 <!doctype html>
-<html lang="en" class="wa-brand-purple">
+<html
+  lang="en"
+  class="wa-brand-purple"
+  data-flags-source={Astro.locals.flagsSource}
+>
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,130 @@
+import { OpenFeature } from '@openfeature/server-sdk';
+import { FlagsmithOpenFeatureProvider } from '@openfeature/flagsmith-provider';
+import { Flagsmith } from 'flagsmith-nodejs';
+import { FLAGSMITH_ENVIRONMENT_KEY } from 'astro:env/server';
+import { type Flags, FLAG_DEFAULTS } from '../types/flags.js';
+
+/**
+ * Lazy singleton promise for provider initialisation.
+ * Reset to null on failure so the next request can retry.
+ */
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Initialise the OpenFeature provider with Flagsmith in Local Evaluation mode.
+ *
+ * Local Evaluation: the Flagsmith SDK fetches the full Environment Document
+ * once at init, then polls every 60s in a background thread. Flag values are
+ * computed in-process — there are no per-request HTTP calls to Flagsmith.
+ *
+ * Requires a "Server-side SDK Token" (not an "Environment API key") in
+ * FLAGSMITH_ENVIRONMENT_KEY. The token type difference is invisible to the
+ * SDK constructor — both are strings — but local evaluation will fail
+ * silently with the wrong key type. See .env.example for setup notes.
+ *
+ * The 2000ms init timeout applies to the initial Environment Document fetch.
+ * Resets `initPromise` on failure so transient errors are retryable.
+ */
+function initProvider(): Promise<void> {
+  if (initPromise !== null) {
+    return initPromise;
+  }
+
+  const key = FLAGSMITH_ENVIRONMENT_KEY;
+
+  // If the key is absent or empty, skip provider init entirely.
+  // Middleware will write FLAG_DEFAULTS and flagsSource='default'.
+  if (!key) {
+    return Promise.resolve();
+  }
+
+  const flagsmithClient = new Flagsmith({
+    environmentKey: key,
+    // Explicit URL — do not rely on the SDK default. Pinning means a
+    // compromised default in a future provider version cannot redirect traffic.
+    apiUrl: 'https://api.flagsmith.com/api/v1/',
+    // Local Evaluation: fetch the full Environment Document once at init,
+    // then poll every 60s in a background thread. Zero per-request HTTP.
+    enableLocalEvaluation: true,
+    environmentRefreshIntervalSeconds: 60,
+    // Required in local evaluation mode — called when a flag name is not
+    // found in the Environment Document. Returning enabled:false matches
+    // our FLAG_DEFAULTS policy (defence in depth alongside FLAG_DEFAULTS).
+    defaultFlagHandler: (_featureName: string) => ({
+      enabled: false,
+      isDefault: true,
+      value: null,
+    }),
+  });
+
+  const provider = new FlagsmithOpenFeatureProvider(flagsmithClient);
+
+  // Wrap setProviderAndWait in a 2000ms timeout.
+  const timeoutMs = 2000;
+  const timeoutPromise = new Promise<void>((_, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(`OpenFeature provider init timed out after ${timeoutMs}ms`)
+        ),
+      timeoutMs
+    );
+    // Allow Node to exit even if this timer is still pending.
+    if (typeof timer === 'object' && 'unref' in timer) {
+      (timer as NodeJS.Timeout).unref();
+    }
+  });
+
+  initPromise = Promise.race([
+    OpenFeature.setProviderAndWait(provider),
+    timeoutPromise,
+  ]).catch((err) => {
+    // Reset so the next request can retry.
+    initPromise = null;
+    throw err;
+  });
+
+  return initPromise;
+}
+
+/**
+ * Ensure the provider is ready. Returns a promise that resolves when the
+ * provider is initialised (or rejects if init fails).
+ */
+export function ensureProviderReady(): Promise<void> {
+  return initProvider();
+}
+
+/**
+ * Resolve all feature flags for the current request.
+ * Calls `getBooleanValue` exactly once per flag.
+ *
+ * The OpenFeature spec guarantees `getBooleanValue` returns `defaultValue`
+ * on TYPE_MISMATCH, FLAG_NOT_FOUND, or any provider error — no additional
+ * type validation is needed.
+ *
+ * An empty evaluation context `{}` is passed explicitly to every call.
+ * This is a regression-prevention measure: if a future PR accidentally
+ * passes user data, code review and tests should catch it.
+ */
+export async function resolveFlags(): Promise<Flags> {
+  const client = OpenFeature.getClient();
+  const ctx = {};
+
+  const [user_accounts_enabled, topic_pages_enabled] = await Promise.all([
+    client.getBooleanValue(
+      'user_accounts_enabled',
+      FLAG_DEFAULTS.user_accounts_enabled,
+      ctx
+    ),
+    client.getBooleanValue(
+      'topic_pages_enabled',
+      FLAG_DEFAULTS.topic_pages_enabled,
+      ctx
+    ),
+  ]);
+
+  return { user_accounts_enabled, topic_pages_enabled };
+}
+
+export { FLAG_DEFAULTS };

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -126,5 +126,3 @@ export async function resolveFlags(): Promise<Flags> {
 
   return { user_accounts_enabled, topic_pages_enabled };
 }
-
-export { FLAG_DEFAULTS };

--- a/src/middleware/flags.ts
+++ b/src/middleware/flags.ts
@@ -1,0 +1,75 @@
+import { defineMiddleware } from 'astro:middleware';
+import * as Sentry from '@sentry/astro';
+import { ensureProviderReady, resolveFlags } from '../lib/flags.js';
+import { FLAG_DEFAULTS } from '../types/flags.js';
+import { FLAGSMITH_ENVIRONMENT_KEY } from 'astro:env/server';
+
+const MIDDLEWARE_TIMEOUT_MS = 500;
+
+// Tracks whether we've already sent a Sentry alert for a missing key in this
+// Lambda instance. Resets on cold start. Prevents per-request event spam.
+let missingKeyReported = false;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export const flagsMiddleware = defineMiddleware(async (context, next) => {
+  try {
+    const key = FLAGSMITH_ENVIRONMENT_KEY;
+
+    if (!key) {
+      // No key configured — use defaults silently (expected in local dev).
+      context.locals.flags = FLAG_DEFAULTS;
+      context.locals.flagsSource = 'default';
+
+      // In production, a missing key is a misconfiguration — alert via Sentry
+      // once per Lambda instance (not per request, to avoid event spam).
+      if (import.meta.env.PROD && !missingKeyReported) {
+        missingKeyReported = true;
+        Sentry.captureMessage(
+          'FLAGSMITH_ENVIRONMENT_KEY is not set in production; serving flag defaults',
+          'warning'
+        );
+      }
+    } else {
+      // Race provider init against a 500ms middleware-level timeout.
+      // If we time out, serve defaults and let init continue in the background
+      // so the next request benefits from a warm provider.
+      let providerReady = false;
+
+      await Promise.race([
+        ensureProviderReady().then(() => {
+          providerReady = true;
+        }),
+        sleep(MIDDLEWARE_TIMEOUT_MS),
+      ]);
+
+      if (providerReady) {
+        context.locals.flags = await resolveFlags();
+        context.locals.flagsSource = 'remote';
+      } else {
+        // Provider not ready within 500ms — fall back to defaults.
+        // Log a breadcrumb (not captureException) for normal fallback.
+        Sentry.addBreadcrumb({
+          category: 'flags',
+          message:
+            'Flag provider not ready within middleware timeout; using defaults',
+          level: 'warning',
+        });
+        context.locals.flags = FLAG_DEFAULTS;
+        context.locals.flagsSource = 'default';
+      }
+    }
+  } catch (err) {
+    // Any thrown error → defaults + capture.
+    Sentry.captureException(err);
+    context.locals.flags = FLAG_DEFAULTS;
+    context.locals.flagsSource = 'default';
+  }
+
+  // Tag every Sentry transaction with the flag source for observability.
+  Sentry.getCurrentScope().setTag('flags.source', context.locals.flagsSource);
+
+  return next();
+});

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,7 @@
+import { sequence } from 'astro:middleware';
+import { flagsMiddleware } from './flags.js';
+
+// sequence() is used from day one so future PRs (e.g. PR #638 auth middleware)
+// can be added to this list without any structural change:
+//   export const onRequest = sequence(flagsMiddleware, authMiddleware);
+export const onRequest = sequence(flagsMiddleware);

--- a/src/types/flags.ts
+++ b/src/types/flags.ts
@@ -1,0 +1,39 @@
+/**
+ * Feature flags resolved per-request from Flagsmith via OpenFeature.
+ *
+ * All members are boolean and required. Middleware always populates this
+ * interface — downstream code must never need a null guard on `Astro.locals.flags`.
+ *
+ * **Prerendered pages cannot access `Astro.locals.flags`.** Flag-gated UI must
+ * not appear on prerendered pages (e.g. 404.astro, accessibility.astro,
+ * curation-policy.astro).
+ *
+ * **Vue islands** receive flag values only via Astro-rendered props:
+ * ```astro
+ * <MyIsland user-accounts-enabled={Astro.locals.flags.user_accounts_enabled} client:load />
+ * ```
+ * Do not import from `src/lib/flags.ts` or any OpenFeature/Flagsmith package
+ * in client-side code.
+ */
+export interface Flags {
+  /**
+   * Gates the user accounts feature (PR #638).
+   * When true, sign-in UI and account-related routes become available.
+   */
+  user_accounts_enabled: boolean;
+
+  /**
+   * Gates the topic pages feature (PR #575).
+   * When true, topic index and detail pages become available.
+   */
+  topic_pages_enabled: boolean;
+}
+
+/**
+ * Safe defaults used when the Flagsmith provider is unavailable or times out.
+ * All flags default to `false` so unreleased features remain hidden.
+ */
+export const FLAG_DEFAULTS: Flags = {
+  user_accounts_enabled: false,
+  topic_pages_enabled: false,
+};


### PR DESCRIPTION
## Summary

- Adds five entries to the lead agent's bash allow-list, all read-only or trivially reversible.
- Identified during the OpenFeature/Flagsmith PR (#706) session, where each of these commands triggered a permission prompt despite being safe.
- All mutations of remote state remain prompted (push, commit, pr create/edit/merge).

## Added

| Command | Why it's safe |
|---|---|
| `gh pr checks*` | Views CI status |
| `gh pr status*` | Views PR status across repos |
| `gh workflow list*` | Lists workflow definitions |
| `gh workflow view*` | Views workflow contents |
| `git add*` | Stages files; always reversible with `git restore --staged` |

## Deliberately NOT added

- `git push`, `git commit`, `gh pr create`, `gh pr edit`, `gh pr merge` — mutate state outside the working tree
- `git checkout <file>` — can silently clobber unsaved work
- `gh issue create`, `gh issue close` — mutate state

## Files

- `.opencode/agents/lead.md` — opencode YAML enforcement (source of truth)
- `.agents/lead.md` — platform-agnostic prose summary, kept in sync