### PR TITLE
docs(agents): require fresh main before new feature branches

### DIFF
--- a/.agents/lead.md
+++ b/.agents/lead.md
@@ -76,3 +76,4 @@ When collecting reports from multiple agents:
 - If an agent returns no findings, say so — do not invent issues.
 - When scope is ambiguous, ask the user to clarify.
 - Do not create git commits without explicit user instruction. When the user asks, commit and push only after verifying the build.
+- Before creating a new feature branch, always `git checkout main && git pull --ff-only` first. Branching from a stale or in-progress branch causes a merged PR to inherit unrelated history, making the GitHub "Files changed" view misleading even when the actual merge diff is clean.


### PR DESCRIPTION
## Summary

- Adds one rule to `.agents/lead.md`: always `git checkout main && git pull --ff-only` before creating a new feature branch.
- This is the lesson learned from #709, where the lead branched off an in-progress feature branch and the resulting PR's GitHub "Files changed" view looked alarming despite the actual merge diff being a clean 2-file change.

## Why it matters

If branch B is created off branch A while A is still open, and A merges first, then when B merges:
- The actual merge diff to `main` is correct (only B's intended changes).
- But the GitHub PR UI shows all of A's files in "Files changed" because that's the diff between B's tip and the PR's original base.
- This is indistinguishable from a real scope leak without inspecting the merge commit directly.

The rule is one line and trivially mechanical. Costs nothing to follow, prevents a class of confusing PR reviews.

## File

- `.agents/lead.md` — appended one bullet to the Rules section.