### PR TITLE
feat(flags): gate topics feature behind topic_pages_enabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ This project uses OpenFeature with the Flagsmith provider for server-side featur
 1. Add the flag name and JSDoc to the `Flags` interface in `src/types/flags.ts`.
 2. Add a default value (almost always `false`) to `FLAG_DEFAULTS`.
 3. Add a `client.getBooleanValue(...)` call in `resolveFlags()` in `src/lib/flags.ts`.
-4. Create the flag in all three Flagsmith environments (development, preview, production) with default value `false`.
+4. Create the flag in both Flagsmith environments (production and non-prod, where non-prod is shared by deploy-preview and local dev) with default value `false`. Set "server-side only" to true on the flag — this codebase exclusively uses server-side evaluation, and enforcing it at the platform level prevents accidental leakage to any future client-side code.
 5. Read in SSR pages/components via `Astro.locals.flags.your_flag_name`.
 
 ### Key type
@@ -149,7 +149,8 @@ The `<html>` element carries `data-flags-source="remote"` when the Flagsmith pro
 ### Constraints
 
 - **Server-side only.** Do not import from `src/lib/flags.ts` in any client-side code or Vue island.
-- **Prerendered pages cannot read flags.** `Astro.locals.flags` is populated by middleware, which does not run for prerendered routes (404, accessibility, curation-policy). Flag-gated UI must not appear on prerendered pages.
+- **Prerendered pages cannot read flags.** `Astro.locals.flags` is populated by middleware, which does not run for prerendered routes (currently only 404). Flag-gated UI must not appear on prerendered pages.
+- **Pages rendering the primary nav must be SSR.** Because `TheHeader.astro` reads `Astro.locals.flags` to gate nav links, any page using the default layout must have `prerender = false`. The 404 page is an exception: it uses a stripped-down `error.astro` layout (logo only, no nav) so it can stay prerendered.
 - **Vue islands receive flags as props.** Pass values from `Astro.locals.flags` as component props at render time.
 - **Propagation lag.** Flagsmith changes propagate to each warm Lambda instance within ~60s (local evaluation polling interval). Cold-started Lambdas fetch fresh data on init. Anonymous evaluation only — no user identity is passed to Flagsmith.
 - **Empty evaluation context.** All `getBooleanValue` calls pass `{}` explicitly. Do not pass user data — this is a regression-prevention guard.

--- a/src/components/TheHeader.astro
+++ b/src/components/TheHeader.astro
@@ -1,6 +1,7 @@
 ---
 import Logo from '../images/eventua11y_logo_wordmark_white.svg';
 const currentPath = Astro.url.pathname;
+const topicPagesEnabled = Astro.locals.flags.topic_pages_enabled;
 ---
 
 <header id="global-header" class="masthead">
@@ -31,17 +32,21 @@ const currentPath = Astro.url.pathname;
               Past Events
             </a>
           </li>
-          <li class="primaryNav__item">
-            <a
-              class="primaryNav__link"
-              href="/topics"
-              aria-current={currentPath.startsWith('/topics')
-                ? 'page'
-                : undefined}
-            >
-              Topics
-            </a>
-          </li>
+          {
+            topicPagesEnabled && (
+              <li class="primaryNav__item">
+                <a
+                  class="primaryNav__link"
+                  href="/topics"
+                  aria-current={
+                    currentPath.startsWith('/topics') ? 'page' : undefined
+                  }
+                >
+                  Topics
+                </a>
+              </li>
+            )
+          }
         </ul>
       </nav>
       <wa-dropdown id="theme-selector" placement="bottom-end" distance="3">

--- a/src/layouts/error.astro
+++ b/src/layouts/error.astro
@@ -1,0 +1,174 @@
+---
+/**
+ * Error page layout — used for 404 and future 500 pages.
+ *
+ * Users landing here are in a degraded wayfinding state; the primary nav
+ * would compete with recovery actions rather than help them. A minimal
+ * masthead with just the logo keeps the page oriented without adding noise.
+ */
+import '@awesome.me/webawesome/dist/styles/themes/default.css';
+import '@awesome.me/webawesome/dist/styles/utilities/gap.css';
+import '@awesome.me/webawesome/dist/styles/utilities/layout.css';
+import '@awesome.me/webawesome/dist/styles/utilities/visually-hidden.css';
+import '../styles/styles.css';
+import TheFooter from '../components/TheFooter.astro';
+import Logo from '../images/eventua11y_logo_wordmark_white.svg';
+const { title, description, ogType } = Astro.props.frontmatter || Astro.props;
+const defaultDescription =
+  'The calendar of digital accessibility and inclusive design events, curated by Matt Obee.';
+const metaDescription = description || defaultDescription;
+const metaOgType = ogType || 'website';
+const faKitCode = import.meta.env.FA_KIT_CODE || '';
+---
+
+<!doctype html>
+<html
+  lang="en"
+  class="wa-brand-purple"
+  data-flags-source={Astro.locals.flagsSource}
+>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="generator" content="Astro" />
+    <meta name="description" content={metaDescription} />
+    <meta name="keywords" content="accessibility, a11y, events, calendar" />
+    <meta name="robots" content="index, follow" />
+    <meta name="author" content="Matt Obee" />
+    <meta name="theme-color" content="#650fca" />
+    <title>
+      {
+        title
+          ? `${title} - Eventua11y - accessibility and inclusive design events`
+          : 'Eventua11y - accessibility and inclusive design events'
+      }
+    </title>
+    <meta
+      property="og:title"
+      content={title ? `${title} - Eventua11y` : 'Eventua11y'}
+    />
+    <meta property="og:site_name" content="Eventua11y" />
+    <meta property="og:author" content="Matt Obee" />
+    <meta property="og:description" content={metaDescription} />
+    <meta
+      property="og:image"
+      content="https://eventua11y.com/favicon/eventua11y_og_min.png"
+    />
+    <meta property="og:type" content={metaOgType} />
+    <meta property="og:url" content={Astro.url} />
+    <script is:inline>
+      (function () {
+        var storedTheme = null;
+        try {
+          if (typeof localStorage !== 'undefined' && localStorage !== null) {
+            storedTheme = localStorage.getItem('theme');
+          }
+        } catch (e) {}
+        var prefersDarkScheme = window.matchMedia(
+          '(prefers-color-scheme: dark)'
+        ).matches;
+        if (storedTheme) {
+          document.documentElement.setAttribute('data-theme', storedTheme);
+        } else if (prefersDarkScheme) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        } else {
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+      })();
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.usefathom.com" />
+    <link
+      rel="preconnect"
+      href="https://o4505086842437632.ingest.us.sentry.io"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=Roboto+Slab&display=swap"
+      rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400;1,700&family=Roboto+Slab&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/favicon/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/favicon/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/favicon/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/favicon/site.webmanifest" />
+    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).href} />
+    {faKitCode && <meta data-fa-kit-code={faKitCode} />}
+  </head>
+  <body>
+    <a href="#main" class="skip">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 384 512"
+        class="icon"
+        aria-hidden="true"
+        fill="currentColor"
+        ><path
+          d="M342.1 249.9L219.3 372.7c-7.2 7.2-17.1 11.3-27.3 11.3s-20.1-4.1-27.3-11.3L41.9 249.9c-6.4-6.4-9.9-15-9.9-24C32 207.2 47.2 192 65.9 192l62.1 0 0-128c0-17.7 14.3-32 32-32l64 0c17.7 0 32 14.3 32 32l0 128 62.1 0c18.7 0 33.9 15.2 33.9 33.9c0 9-3.6 17.6-9.9 24zM32 416l320 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 480c-17.7 0-32-14.3-32-32s14.3-32 32-32z"
+        ></path></svg
+      > Skip to main content
+    </a>
+
+    <header id="global-header" class="masthead">
+      <div class="inner">
+        <div class="masthead__logo">
+          <a href="/" rel="home">
+            <Logo class="logo" aria-label="Eventua11y" />
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <main id="main">
+      <slot />
+    </main>
+
+    <TheFooter />
+    <script src="https://cdn.usefathom.com/script.js" data-site="XTSPEPUF" defer
+    ></script>
+  </body>
+</html>
+
+<script>
+  // Web Awesome component imports (cherry-picked for tree-shaking)
+  import '@awesome.me/webawesome/dist/components/badge/badge.js';
+  import '@awesome.me/webawesome/dist/components/button/button.js';
+  import '@awesome.me/webawesome/dist/components/callout/callout.js';
+  import '@awesome.me/webawesome/dist/components/card/card.js';
+  import '@awesome.me/webawesome/dist/components/divider/divider.js';
+  import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
+  import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';
+  import '@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js';
+  import '@awesome.me/webawesome/dist/components/icon/icon.js';
+  import '@awesome.me/webawesome/dist/components/option/option.js';
+  import '@awesome.me/webawesome/dist/components/radio/radio.js';
+  import '@awesome.me/webawesome/dist/components/radio-group/radio-group.js';
+  import '@awesome.me/webawesome/dist/components/select/select.js';
+  import '@awesome.me/webawesome/dist/components/switch/switch.js';
+  import '@awesome.me/webawesome/dist/components/progress-bar/progress-bar.js';
+
+  import '../scripts/main.ts';
+</script>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,12 +1,12 @@
 ---
 export const prerender = true;
-import DefaultLayout from '../layouts/default.astro';
+import ErrorLayout from '../layouts/error.astro';
 ---
 
-<DefaultLayout title="Page not found">
+<ErrorLayout title="Page not found">
   <div class="container readable py-l flow">
     <h1>Page not found</h1>
     <p>The page you're looking for doesn't exist or may have been moved.</p>
     <p>Try browsing <a href="/">upcoming accessibility events</a> instead.</p>
   </div>
-</DefaultLayout>
+</ErrorLayout>

--- a/src/pages/accessibility.astro
+++ b/src/pages/accessibility.astro
@@ -1,5 +1,5 @@
 ---
-export const prerender = true;
+export const prerender = false;
 import DefaultLayout from '../layouts/default.astro';
 ---
 

--- a/src/pages/curation-policy.astro
+++ b/src/pages/curation-policy.astro
@@ -1,5 +1,5 @@
 ---
-export const prerender = true;
+export const prerender = false;
 import DefaultLayout from '../layouts/default.astro';
 ---
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -50,7 +50,10 @@ const metaDescription = event.description
 
 // Check states
 const callForSpeakersOpen = isCallForSpeakersOpen(event);
-const hasTopics = Array.isArray(event.topics) && event.topics.length > 0;
+const hasTopics =
+  Astro.locals.flags.topic_pages_enabled &&
+  Array.isArray(event.topics) &&
+  event.topics.length > 0;
 const hasChildren = Array.isArray(event.children) && event.children.length > 0;
 const isChildEvent = !!event.parent;
 const parentUrl = event.parentEvent?.slug?.current

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -75,15 +75,20 @@ function toW3CDate(isoDate?: string): string {
   return date.toISOString().split('T')[0];
 }
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async (context) => {
   const site = 'https://eventua11y.com';
   const today = new Date().toISOString().split('T')[0];
+  const topicsEnabled = context.locals.flags.topic_pages_enabled;
 
-  // Fetch all event and topic slugs from Sanity
+  // Fetch event and topic slugs from Sanity (topics only when flag is on)
   let events: SitemapEvent[] = [];
   let topics: SitemapTopic[] = [];
   try {
-    [events, topics] = await Promise.all([getEventSlugs(), getTopicSlugs()]);
+    if (topicsEnabled) {
+      [events, topics] = await Promise.all([getEventSlugs(), getTopicSlugs()]);
+    } else {
+      events = await getEventSlugs();
+    }
   } catch {
     // If Sanity is unreachable, generate sitemap with static pages only.
     // This ensures crawlers still get a valid response.
@@ -112,12 +117,16 @@ export const GET: APIRoute = async () => {
       priority: '0.5',
       lastmod: today,
     },
-    {
-      loc: '/topics',
-      changefreq: 'weekly',
-      priority: '0.6',
-      lastmod: today,
-    },
+    ...(topicsEnabled
+      ? [
+          {
+            loc: '/topics',
+            changefreq: 'weekly',
+            priority: '0.6',
+            lastmod: today,
+          },
+        ]
+      : []),
   ];
 
   const urlEntries = staticPages

--- a/src/pages/topics/[slug].astro
+++ b/src/pages/topics/[slug].astro
@@ -22,6 +22,10 @@ export const prerender = false;
 
 const { slug } = Astro.params;
 
+if (!Astro.locals.flags.topic_pages_enabled) {
+  return Astro.redirect('/404');
+}
+
 if (!slug) {
   return Astro.redirect('/404');
 }

--- a/src/pages/topics/index.astro
+++ b/src/pages/topics/index.astro
@@ -12,6 +12,10 @@ import { getTopics } from '../../lib/sanity';
 
 export const prerender = false;
 
+if (!Astro.locals.flags.topic_pages_enabled) {
+  return Astro.redirect('/404');
+}
+
 const topics = await getTopics();
 
 Astro.response.headers.set(

--- a/tests/topics-flag.spec.ts
+++ b/tests/topics-flag.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Tests for the `topic_pages_enabled` feature flag gating all topic surfaces.
+ *
+ * The flag defaults to `false` in all environments. These tests verify the
+ * flag-off (default) behaviour only.
+ *
+ * FLAG-ON BEHAVIOUR (topic_pages_enabled = true):
+ * Cannot be tested here because Flagsmith cannot be toggled from Playwright.
+ * Flag-on state must be verified manually in a deploy preview by enabling the
+ * flag in the Flagsmith non-production environment, then checking:
+ *   - /topics returns 200 and renders the topics index
+ *   - /topics/<slug> returns 200 and renders the topic detail page
+ *   - The header nav contains a "Topics" link
+ *   - /sitemap.xml contains /topics and individual topic URLs
+ *   - Event detail pages with topics show the .event-detail__topics chip block
+ *
+ * TODO: If a Flagsmith mock/stub mechanism is added to the test infrastructure,
+ * revisit and add flag-on assertions here.
+ */
+
+test.describe('Topics feature flag — flag OFF (default)', () => {
+  test('/topics redirects to 404 when flag is off', async ({ page }) => {
+    const response = await page.goto('/topics');
+    // The page redirects to /404; follow the redirect and check the final URL
+    const url = page.url();
+    expect(url).toContain('404');
+  });
+
+  test('/topics/[slug] redirects to 404 when flag is off', async ({ page }) => {
+    const response = await page.goto('/topics/some-slug');
+    const url = page.url();
+    expect(url).toContain('404');
+  });
+
+  test('header nav does not contain a Topics link when flag is off', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    // Wait for the server-rendered header to be present
+    await page.waitForSelector('#global-header');
+
+    const topicsLink = page
+      .getByRole('navigation')
+      .getByRole('link', { name: 'Topics' });
+    await expect(topicsLink).toHaveCount(0);
+  });
+
+  test('sitemap does not include /topics URLs when flag is off', async ({
+    page,
+  }) => {
+    const response = await page.goto('/sitemap.xml');
+    expect(response).not.toBeNull();
+    const body = await page.content();
+    expect(body).not.toContain('/topics');
+  });
+
+  /**
+   * Topic chips on event detail pages (/events/[slug]):
+   *
+   * The .event-detail__topics block is omitted from the DOM when the flag is
+   * off AND the event has topics. We cannot assert its absence on a known event
+   * without first confirming that event has topics in the test dataset.
+   *
+   * TODO: Query the test dataset for an event with at least one topic, then add:
+   *   await page.goto(`/events/${slugWithTopics}`);
+   *   await expect(page.locator('.event-detail__topics')).toHaveCount(0);
+   *
+   * For now this surface is covered implicitly: if the flag gate works for
+   * /topics and the nav link, the same `hasTopics` boolean (which requires the
+   * flag) drives the chip block, so a regression there would be caught by a
+   * manual flag-on smoke test.
+   */
+});


### PR DESCRIPTION
## Summary

Gates the entire `topics` feature behind the `topic_pages_enabled` server-side flag so the feature in #575 can ship dark and be enabled later by flipping the Flagsmith toggle — no redeploy needed.

## What's gated

When `topic_pages_enabled` is off (the default):

- `/topics` and `/topics/[slug]` redirect to `/404`
- Topic chips on `/events/[slug]` are not rendered
- Topics link is omitted from the primary nav
- `/topics` and individual topic URLs are omitted from `sitemap.xml`

## Side changes (and why)

`Astro.locals.flags` is undefined on prerendered pages because the middleware doesn't run for static HTML, so a flag-aware nav link in `TheHeader.astro` would behave inconsistently across the site. To fix that without breaking Netlify's automatic 404 handling:

- New `src/layouts/error.astro` (logo-only chrome, no nav). Used by `404.astro`, which stays prerendered. Future error pages (e.g. 500) can reuse it.
- `accessibility.astro` and `curation-policy.astro` flipped to SSR so they can render the flag-aware header.
- New `AGENTS.md` rule: pages rendering the primary nav must be SSR (404 excepted via the error layout).

## Testing

- `tests/topics-flag.spec.ts` — 4 Playwright E2E tests covering all flag-off behaviours.
- Flag-on path will be verified manually on the deploy preview by toggling `topic_pages_enabled` to `true` in the Flagsmith **non-prod** environment, then back to `false` before merge.
- Topic chips on event-detail pages are not E2E-tested (no known event with topics in the test dataset). Implicitly covered by existing tests (event pages still render correctly when the topics block is absent).

## Pre-merge checklist

- [ ] Confirm `topic_pages_enabled` exists in **both** Flagsmith environments (production + non-prod), default `false`, "server-side only" = true.
- [ ] Manual deploy-preview verification with flag on: `/topics`, `/topics/[slug]`, nav link, topic chips on a real event with topics, `sitemap.xml`.
- [ ] Flag back to `false` in non-prod before merge.

## Accessibility

Reviewed by the accessibility agent. Pass — 0 critical, 0 serious, 2 best-practice notes (neither blocking).