### PR TITLE
Icon-only Filter button on narrow viewports

### DIFF
--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -41,7 +41,13 @@
             appearance="outlined"
             data-drawer="open filter-drawer"
           >
-            <wa-icon slot="start" name="filter" auto-width></wa-icon> Filter
+            <wa-icon
+              :slot="isNarrow ? undefined : 'start'"
+              name="filter"
+              :label="isNarrow ? 'Filter' : undefined"
+              auto-width
+            ></wa-icon>
+            <span v-if="!isNarrow">Filter</span>
           </wa-button>
           <TimezoneSelector />
         </div>
@@ -51,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, onMounted, onUnmounted, nextTick } from 'vue';
 import filtersStore from '../store/filtersStore';
 import TimezoneSelector from './TimezoneSelector.vue';
 
@@ -72,6 +78,17 @@ const filterToolbar = ref(null);
  * Used to ensure proper initialization of checked state
  */
 const awarenessDaysSwitch = ref(null);
+
+/**
+ * Tracks whether the viewport is narrow (≤699.98px)
+ * Used to switch the Filter button between icon-only and icon+label modes
+ */
+const isNarrow = ref(false);
+let mql: MediaQueryList | null = null;
+
+function updateIsNarrow(e: MediaQueryListEvent | MediaQueryList) {
+  isNarrow.value = e.matches;
+}
 
 /**
  * Resets all filters to default values
@@ -116,5 +133,22 @@ onMounted(async () => {
     );
     observer.observe(filterToolbar.value);
   }
+
+  mql = window.matchMedia('(max-width: 699.98px)');
+  isNarrow.value = mql.matches;
+  mql.addEventListener('change', updateIsNarrow);
+});
+
+onUnmounted(() => {
+  if (mql) mql.removeEventListener('change', updateIsNarrow);
 });
 </script>
+
+<style>
+@media (max-width: 699.98px) {
+  /* Defensive: ensure icon-only Filter button meets WCAG 2.2 SC 2.5.8 (24×24 minimum touch target) */
+  #open-filter-drawer {
+    min-width: 2.5rem;
+  }
+}
+</style>

--- a/src/styles/_filters.css
+++ b/src/styles/_filters.css
@@ -32,6 +32,14 @@
       wa-dropdown {
         width: 100%;
       }
+      @media (max-width: calc(700px - 0.01px)) {
+        > #open-filter-drawer {
+          flex: 0 0 auto;
+        }
+        wa-button#open-filter-drawer {
+          width: auto;
+        }
+      }
       @media (min-width: 700px) {
         > wa-button,
         > wa-dropdown {


### PR DESCRIPTION
## Summary

- Switches the Filter button to icon-only below 700px using Web Awesome 3's native icon-button pattern (`:state(icon-button)` auto-activates when only a `<wa-icon>` is slotted).
- Recovers horizontal space for the TimezoneSelector dropdown, which was previously truncating "Event local time" → "Event local ti…" in narrow viewports.
- Uses a `matchMedia` listener to reactively switch DOM markup at the breakpoint, so the icon's `label` attribute provides the accessible name when icon-only and the visible text span provides it when wide.

## Implementation notes

- **Why DOM toggle (not `.sr-only`)**: Web Awesome's `:state(icon-button)` only activates when the button has no other slotted content. Hiding text with `.sr-only` would leave it in the DOM and block native icon-button sizing/centering. Confirmed via WA docs and accessibility review.
- **Accessible name source**: At narrow widths the `<wa-icon label="Filter">` provides the name; at wide widths the visible `<span>Filter</span>` provides it. No double-naming.
- **Layout**: `_filters.css` already had a `.group > * { flex: 1 }` rule below 700px — added an override so `#open-filter-drawer` shrinks to natural width while TimezoneSelector continues to grow.
- **Touch target**: Defensive `min-width: 2.5rem` at narrow widths as a WCAG 2.2 SC 2.5.8 safeguard until WA's native icon-button sizing is verified in-browser.

## Follow-up flagged (not done in this PR)

`tests/accessibility.spec.ts:152` asserts `toContainText('Filter')` on the button. Currently passes at default Playwright viewport (1280×720). If narrow-viewport test runs are added, switch the assertion to `toHaveAccessibleName('Filter')` which works at any viewport.