### PR TITLE
fix(a11y): remove middot from event website link clickable region

### DIFF
--- a/src/components/EventDelivery.vue
+++ b/src/components/EventDelivery.vue
@@ -96,6 +96,7 @@ const locationIcon = computed(() =>
     </div>
 
     <template v-if="website && showWebsiteLink">
+      <span aria-hidden="true" class="event__delivery-separator">·</span>
       <a
         :href="website"
         rel="noopener noreferrer"

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -131,6 +131,9 @@ const displayLocation = event.location || 'International';
           )}
           {event.website && !isTheme && (
             <Fragment>
+              <span aria-hidden="true" class="event__delivery-separator">
+                ·
+              </span>
               <a
                 href={event.website}
                 rel="noopener noreferrer"
@@ -151,6 +154,9 @@ const displayLocation = event.location || 'International';
           </span>
           {event.website && !isTheme && (
             <Fragment>
+              <span aria-hidden="true" class="event__delivery-separator">
+                ·
+              </span>
               <a
                 href={event.website}
                 rel="noopener noreferrer"

--- a/src/styles/_events.css
+++ b/src/styles/_events.css
@@ -67,9 +67,15 @@
     row-gap: 0;
     align-items: baseline;
   }
+}
 
-  .event__delivery > .event__website-link::before {
-    content: '·';
+.event__delivery-separator {
+  display: none;
+}
+
+@media (min-width: 48rem) {
+  .event__delivery-separator {
+    display: inline;
     margin-right: 0.5em;
   }
 }

--- a/src/styles/_events.css
+++ b/src/styles/_events.css
@@ -76,7 +76,6 @@
 @media (min-width: 48rem) {
   .event__delivery-separator {
     display: inline;
-    margin-right: 0.5em;
   }
 }
 


### PR DESCRIPTION
## Summary

- The middot separator (`·`) before "Event website" links was rendered via a `::before` pseudo-element on the `<a>` itself, introduced in e2f52a1 when `.event__delivery` was refactored to flexbox.
- Pseudo-element content is part of the link's accessible name and click target. Screen readers may announce "· Event website", and the dot was clickable as part of the link.
- Move the middot to a real `<span aria-hidden="true">` sibling before the link in `EventDelivery.vue` and `StaticEvent.astro`, gated to ≥48rem viewports via a new `.event__delivery-separator` class.

## Changes

- `src/styles/_events.css` — Remove `::before` rule on `.event__website-link`; add `.event__delivery-separator` (hidden <48rem, inline ≥48rem).
- `src/components/EventDelivery.vue` — Insert separator span before the website-link template.
- `src/components/StaticEvent.astro` — Insert separator span before both website-link instances.

## Verification

- `npm run build` ✅
- `npm run prettier:check` ✅
- Manual browser check recommended at ≥48rem and <48rem viewports to confirm visual parity with the previous behaviour.
- Tests deferred to CI.