### PR TITLE
Restore inline comma-separated speaker list

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -320,7 +320,7 @@ const jsonLd = {
               <h2 class="text-large">
                 {allSpeakers.length === 1 ? 'Speaker' : 'Speakers'}
               </h2>
-              <ul role="list" class="event-detail__speaker-list flow flow-xs">
+              <ul role="list" class="event-detail__speaker-list">
                 {allSpeakers.map((speaker) => (
                   <li>
                     <span>{speaker.name}</span>


### PR DESCRIPTION
## Summary
- Removes `flow flow-xs` from the `<ul class="event-detail__speaker-list">` so the inline comma-separated layout from PR #570 works again.
- Parent `.event-detail__speakers` keeps its `flow` class for heading-to-list spacing.

## Cause
Commit 2e14900 in PR #575 added `flow flow-xs` to the speaker list `<ul>`. The flow utility sets `display: flex; flex-direction: column;` and adds vertical margin between siblings, overriding the inline row layout from PR #570.

## Verification
- `npm run build` ✓
- `npm run prettier:check` ✓
- Visible on /events/accessgiven-2026