### PR TITLE
fix: remove spurious space before comma in speaker list

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -234,10 +234,7 @@ const jsonLd = {
                         {' '}
                         {formatPreposition}{' '}
                         {allSpeakers.map((speaker, i) => (
-                          <Fragment>
-                            {i > 0 && ', '}
-                            <span>{speaker.name}</span>
-                          </Fragment>
+                          <Fragment>{i > 0 && ', '}<span>{speaker.name}</span></Fragment>
                         ))}
                       </Fragment>
                     )}

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -233,12 +233,7 @@ const jsonLd = {
                       <Fragment>
                         {' '}
                         {formatPreposition}{' '}
-                        {allSpeakers.map((speaker, i) => (
-                          <span>
-                            {i > 0 && ', '}
-                            {speaker.name}
-                          </span>
-                        ))}
+                        {allSpeakers.map((s) => s.name).join(', ')}
                       </Fragment>
                     )}
                   </span>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -234,7 +234,10 @@ const jsonLd = {
                         {' '}
                         {formatPreposition}{' '}
                         {allSpeakers.map((speaker, i) => (
-                          <Fragment>{i > 0 && ', '}<span>{speaker.name}</span></Fragment>
+                          <span>
+                            {i > 0 && ', '}
+                            {speaker.name}
+                          </span>
                         ))}
                       </Fragment>
                     )}


### PR DESCRIPTION
## Summary

- Fixes a space appearing before the comma in multi-speaker event subtitles (e.g. `Workshop with Anna Bommas , Lisa Crispin`).
- Root cause: JSX whitespace text nodes between the comma and the speaker name `<span>` elements, which were vestigial from a previous inline microdata implementation.
- Fix: removed the spans entirely and replaced the map with a plain `.join(', ')`.