### PR TITLE
feat(event): show supplementary links in detail sidebar

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -380,8 +380,7 @@ const jsonLd = {
                 {event.website && (
                   <wa-button
                     href={event.website}
-                    rel="noopener noreferrer"
-                    target="_blank"
+                    rel="external"
                     variant="neutral"
                     appearance="accent"
                     style="width: 100%;"
@@ -398,21 +397,11 @@ const jsonLd = {
                     <ul role="list" class="event-detail-sidebar__links">
                       {supplementaryLinks.map((link) => (
                         <li>
-                          <wa-button
-                            href={link.href}
-                            rel="noopener noreferrer"
-                            target="_blank"
-                            appearance="plain"
-                            variant="neutral"
-                            size="small"
-                          >
+                          <a href={link.href} rel="external">
                             {link.label}
                             <span class="sr-only"> (opens external site)</span>
-                            <wa-icon
-                              slot="end"
-                              name="arrow-up-right-from-square"
-                            />
-                          </wa-button>
+                            <wa-icon name="arrow-up-right-from-square" />
+                          </a>
                         </li>
                       ))}
                     </ul>
@@ -636,17 +625,10 @@ const jsonLd = {
     gap: var(--p-space-2xs);
   }
 
-  .event-detail-sidebar__links li {
-    display: block;
-  }
-
-  .event-detail-sidebar__links wa-button {
-    display: block;
-    width: 100%;
-  }
-
-  .event-detail-sidebar__links wa-button::part(base) {
-    justify-content: flex-start;
+  .event-detail-sidebar__links a {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--p-space-3xs);
   }
 
   @media (min-width: 769px) {

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -631,8 +631,6 @@ const jsonLd = {
     list-style: none;
     padding: 0;
     margin-top: var(--p-space-xs);
-    padding-top: var(--p-space-xs);
-    border-top: 1px solid var(--s-color-border);
     display: flex;
     flex-direction: column;
     gap: var(--p-space-2xs);

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -109,6 +109,31 @@ const enumeratedChildTypes = (() => {
   return `${joined} at ${event.title}`;
 })();
 
+// Supplementary sidebar links
+const supplementaryLinks = [
+  event.registration && { href: event.registration, label: 'Registration' },
+  event.codeOfConduct && {
+    href: event.codeOfConduct,
+    label: 'Code of conduct',
+  },
+  event.accessibilityInfo?.url && {
+    href: event.accessibilityInfo.url,
+    label: 'Accessibility information',
+    summary: event.accessibilityInfo.summary,
+  },
+  event.schedule && { href: event.schedule, label: 'Schedule' },
+  event.callForSpeakersLink && {
+    href: event.callForSpeakersLink,
+    label: 'Call for speakers',
+  },
+].filter(Boolean) as Array<{ href: string; label: string; summary?: string }>;
+
+const hasAccessibilitySummaryOnly =
+  event.accessibilityInfo?.summary && !event.accessibilityInfo?.url;
+
+const hasSidebarLinks =
+  supplementaryLinks.length > 0 || hasAccessibilitySummaryOnly;
+
 // JSON-LD structured data
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -302,7 +327,7 @@ const jsonLd = {
 
       <div class="event-detail-body">
         {
-          (event.website || event.organizer) && (
+          (event.website || event.organizer || hasSidebarLinks) && (
             <aside class="event-detail-sidebar">
               <wa-card class="event-detail-sidebar__card" appearance="outlined">
                 <p>
@@ -371,8 +396,63 @@ const jsonLd = {
                     style="width: 100%;"
                   >
                     Event website
+                    <span class="sr-only"> (opens external site)</span>
                     <wa-icon slot="end" name="arrow-up-right-from-square" />
                   </wa-button>
+                )}
+                {hasSidebarLinks && (
+                  <>
+                    <h2 class="sr-only">Event resources</h2>
+                    <ul role="list" class="event-detail-sidebar__links">
+                      {supplementaryLinks.map((link) =>
+                        link.label === 'Accessibility information' &&
+                        link.summary ? (
+                          <li>
+                            <a
+                              href={link.href}
+                              rel="noopener noreferrer"
+                              target="_blank"
+                              aria-describedby="a11y-info-summary"
+                            >
+                              {link.label}
+                              <wa-icon
+                                name="arrow-up-right-from-square"
+                                label="(opens external site)"
+                              />
+                            </a>
+                            <p
+                              id="a11y-info-summary"
+                              class="text-small text-muted"
+                            >
+                              {link.summary}
+                            </p>
+                          </li>
+                        ) : (
+                          <li>
+                            <a
+                              href={link.href}
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              {link.label}
+                              <wa-icon
+                                name="arrow-up-right-from-square"
+                                label="(opens external site)"
+                              />
+                            </a>
+                          </li>
+                        )
+                      )}
+                      {hasAccessibilitySummaryOnly &&
+                        !event.accessibilityInfo?.url && (
+                          <li>
+                            <p class="text-small text-muted">
+                              Accessibility: {event.accessibilityInfo!.summary}
+                            </p>
+                          </li>
+                        )}
+                    </ul>
+                  </>
                 )}
               </wa-card>
             </aside>
@@ -581,6 +661,27 @@ const jsonLd = {
 
   .event-detail-sidebar__card wa-button {
     margin-top: var(--p-space-xs);
+  }
+
+  .event-detail-sidebar__links {
+    list-style: none;
+    padding: 0;
+    margin-top: var(--p-space-xs);
+    padding-top: var(--p-space-xs);
+    border-top: 1px solid var(--s-color-border);
+    display: flex;
+    flex-direction: column;
+    gap: var(--p-space-2xs);
+  }
+
+  .event-detail-sidebar__links a {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--p-space-3xs);
+  }
+
+  .event-detail-sidebar__links p {
+    margin: var(--p-space-3xs) 0 0;
   }
 
   @media (min-width: 769px) {

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -385,6 +385,7 @@ const jsonLd = {
                     variant="neutral"
                     appearance="accent"
                     style="width: 100%;"
+                    class="event-detail-sidebar__website-button"
                   >
                     Event website
                     <span class="sr-only"> (opens external site)</span>
@@ -622,7 +623,7 @@ const jsonLd = {
     font-size: var(--p-step--1);
   }
 
-  .event-detail-sidebar__card wa-button {
+  .event-detail-sidebar__website-button {
     margin-top: var(--p-space-xs);
   }
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -116,23 +116,14 @@ const supplementaryLinks = [
     href: event.codeOfConduct,
     label: 'Code of conduct',
   },
-  event.accessibilityInfo?.url && {
-    href: event.accessibilityInfo.url,
-    label: 'Accessibility information',
-    summary: event.accessibilityInfo.summary,
-  },
   event.schedule && { href: event.schedule, label: 'Schedule' },
   event.callForSpeakersLink && {
     href: event.callForSpeakersLink,
     label: 'Call for speakers',
   },
-].filter(Boolean) as Array<{ href: string; label: string; summary?: string }>;
+].filter(Boolean) as Array<{ href: string; label: string }>;
 
-const hasAccessibilitySummaryOnly =
-  event.accessibilityInfo?.summary && !event.accessibilityInfo?.url;
-
-const hasSidebarLinks =
-  supplementaryLinks.length > 0 || hasAccessibilitySummaryOnly;
+const hasSidebarLinks = supplementaryLinks.length > 0;
 
 // JSON-LD structured data
 const jsonLd = {
@@ -404,53 +395,25 @@ const jsonLd = {
                   <>
                     <h2 class="sr-only">Event resources</h2>
                     <ul role="list" class="event-detail-sidebar__links">
-                      {supplementaryLinks.map((link) =>
-                        link.label === 'Accessibility information' &&
-                        link.summary ? (
-                          <li>
-                            <a
-                              href={link.href}
-                              rel="noopener noreferrer"
-                              target="_blank"
-                              aria-describedby="a11y-info-summary"
-                            >
-                              {link.label}
-                              <wa-icon
-                                name="arrow-up-right-from-square"
-                                label="(opens external site)"
-                              />
-                            </a>
-                            <p
-                              id="a11y-info-summary"
-                              class="text-small text-muted"
-                            >
-                              {link.summary}
-                            </p>
-                          </li>
-                        ) : (
-                          <li>
-                            <a
-                              href={link.href}
-                              rel="noopener noreferrer"
-                              target="_blank"
-                            >
-                              {link.label}
-                              <wa-icon
-                                name="arrow-up-right-from-square"
-                                label="(opens external site)"
-                              />
-                            </a>
-                          </li>
-                        )
-                      )}
-                      {hasAccessibilitySummaryOnly &&
-                        !event.accessibilityInfo?.url && (
-                          <li>
-                            <p class="text-small text-muted">
-                              Accessibility: {event.accessibilityInfo!.summary}
-                            </p>
-                          </li>
-                        )}
+                      {supplementaryLinks.map((link) => (
+                        <li>
+                          <wa-button
+                            href={link.href}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            appearance="plain"
+                            variant="neutral"
+                            size="small"
+                          >
+                            {link.label}
+                            <span class="sr-only"> (opens external site)</span>
+                            <wa-icon
+                              slot="end"
+                              name="arrow-up-right-from-square"
+                            />
+                          </wa-button>
+                        </li>
+                      ))}
                     </ul>
                   </>
                 )}
@@ -674,14 +637,17 @@ const jsonLd = {
     gap: var(--p-space-2xs);
   }
 
-  .event-detail-sidebar__links a {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--p-space-3xs);
+  .event-detail-sidebar__links li {
+    display: block;
   }
 
-  .event-detail-sidebar__links p {
-    margin: var(--p-space-3xs) 0 0;
+  .event-detail-sidebar__links wa-button {
+    display: block;
+    width: 100%;
+  }
+
+  .event-detail-sidebar__links wa-button::part(base) {
+    justify-content: flex-start;
   }
 
   @media (min-width: 769px) {

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -52,6 +52,11 @@ export interface Event {
   location?: string;
   isFree?: boolean;
   website?: string;
+  registration?: string;
+  codeOfConduct?: string;
+  accessibilityInfo?: { url?: string; summary?: string };
+  schedule?: string;
+  callForSpeakersLink?: string;
   parent?: { _ref: string };
   parentEvent?: { title: string; slug?: { current: string } };
   children?: ChildEvent[];

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -54,7 +54,6 @@ export interface Event {
   website?: string;
   registration?: string;
   codeOfConduct?: string;
-  accessibilityInfo?: { url?: string; summary?: string };
   schedule?: string;
   callForSpeakersLink?: string;
   parent?: { _ref: string };


### PR DESCRIPTION
## Summary

- Surfaces the new event link fields from [eventua11y-sanity#242](https://github.com/eventua11y/eventua11y-sanity/pull/242) (`registration`, `codeOfConduct`, `accessibilityInfo`, `schedule`, `callForSpeakersLink`) inside the event detail sidebar card, below the existing "Event website" button.
- Accessibility info renders link + summary together when both are present, associated via `aria-describedby` so the summary is announced as the link's description. When only a summary is present (no URL), it renders as plain text in the list.
- Drive-by fix on the "Event website" button: external-link indication was visual only. Added sr-only "(opens external site)" text to match the pattern used in `StaticEvent.astro`.

## Markup pattern

Per the accessibility specialist's Coder Requirements:

- Visually-hidden `<h2>Event resources</h2>` so screen reader users navigating by heading can find the section
- `<ul role="list">` (the `role="list"` is needed because `list-style: none` removes list semantics in WebKit)
- Each link uses `target="_blank"` + `rel="noopener noreferrer"` and a `<wa-icon label="(opens external site)">` to convey the external-link affordance to AT users
- Render order prioritises action-oriented links: Registration → Code of conduct → Accessibility information → Schedule → Call for speakers

## GROQ query

`getEventBySlug` already uses `...` at the root, so the new fields come through automatically — no query change needed. Listing queries are untouched (these fields aren't surfaced in cards).

## Out of scope

- Parent-event inheritance (`coalesce(field, parent->field)`) for the new link fields, by analogy with how `website` works. Worth considering as a follow-up — child events of multi-day conferences might reasonably inherit a parent's code of conduct and accessibility info — but adding that here would broaden the change and warrants its own discussion.
- Tests. The existing accessibility test suite scans the event detail page with axe; this PR doesn't change the page's accessibility surface in a way that needs new assertions, and the new fields' visibility is conditional on Sanity content that doesn't currently exist in production.

## Verification

- `npm run build` passes
- Accessibility specialist consulted during planning (produced Coder Requirements) and after implementation (audit passed clean)