### PR TITLE
fix(event): strip null topic and speaker refs before render

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -35,6 +35,19 @@ if (!event) {
   return Astro.redirect('/404');
 }
 
+// Defensive: GROQ `field[]->{...}` returns null entries when a referenced
+// document is unpublished or deleted. Strip those before any consumer maps over them.
+if (Array.isArray(event.topics)) {
+  event.topics = event.topics.filter(
+    (t): t is NonNullable<typeof t> => t != null
+  );
+}
+if (Array.isArray(event.speakers)) {
+  event.speakers = event.speakers.filter(
+    (s): s is NonNullable<typeof s> => s != null
+  );
+}
+
 // Cache the response to reduce Sanity API calls, matching the
 // strategy used by the get-events edge function.
 Astro.response.headers.set(


### PR DESCRIPTION
## Summary

- Strips null entries from `event.topics` and `event.speakers` after fetching from Sanity, preventing a `TypeError: Cannot read properties of null (reading 'name')` 500 on event detail pages whose referenced topic or speaker documents have been deleted/unpublished.
- Sentry: [EVENTUA11Y-14](https://matt-obee.sentry.io/issues/EVENTUA11Y-14), [EVENTUA11Y-15](https://matt-obee.sentry.io/issues/EVENTUA11Y-15).

## Background

GROQ `field[]->{...}` returns `null` entries when a referenced document is unresolved (deleted or unpublished). The event detail page (`src/pages/events/[slug].astro`) maps over `event.topics` and `event.speakers` without guarding for nulls — both in the JSON-LD builder (`topic.name`) and in the sidebar render (`topic.slug.current`, `topic.name`).

## Why fix in TS, not GROQ

The first attempt (commit `9f80e44`) appended `[defined(_id)]` to the GROQ projections in `src/lib/sanity.ts`. This **broke other event pages** — likely because the trailing filter altered the result shape when `topics`/`speakers` was itself null/undefined on the source document. That commit was reverted in `2e8ff92`.

Filtering at the consumer is safer: it doesn't change the query shape, it's narrowly scoped to the page that actually renders these fields, and the type narrowing is explicit.

## Test plan

- [x] `npm run build` clean
- [ ] Verify `/events/open-source-assistive-technology-hackathon` returns 200 after deploy
- [ ] Verify other event pages still render
- [ ] `EVENTUA11Y-14` and `EVENTUA11Y-15` auto-resolve on merge

## Note

Direct push to `main` would normally be acceptable for a one-line fix, but a previous attempt at this fix broke production. PR'd this time so the deploy preview can be checked before merge.