### PR TITLE
feat(event): inherit parent event links on child events

### DIFF
--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -171,6 +171,11 @@ export async function getEventBySlug(slug: string): Promise<Event | null> {
     *[_type == "event" && slug.current == $slug && !(_id in path("drafts.**"))][0] {
       ...,
       "website": coalesce(website, parent->website),
+      "registration": coalesce(registration, parent->registration),
+      "codeOfConduct": coalesce(codeOfConduct, parent->codeOfConduct),
+      "accessibilityInfo": coalesce(accessibilityInfo, parent->accessibilityInfo),
+      "schedule": coalesce(schedule, parent->schedule),
+      "callForSpeakersLink": coalesce(callForSpeakersLink, parent->callForSpeakersLink),
       "attendanceMode": coalesce(attendanceMode, parent->attendanceMode),
       "location": coalesce(location, parent->location),
       "parentEvent": parent->{ title, slug },


### PR DESCRIPTION
## Summary

- Child events now inherit `registration`, `codeOfConduct`, `accessibilityInfo`, `schedule`, and `callForSpeakersLink` from their parent event when those fields are not set on the child.
- A child event that sets its own value for any of these fields overrides the parent's value.
- Matches the existing `coalesce(field, parent->field)` pattern already in place for `website`, `attendanceMode`, `location`, and `organizer`.

## Why

Sub-events (e.g. individual sessions of a multi-day conference) typically share the parent event's registration page, code of conduct, accessibility info, schedule, and call-for-speakers link. Editors should not have to copy these onto every child.

## How

In `getEventBySlug` (`src/lib/sanity.ts`), added five `coalesce(field, parent->field)` projections alongside the existing four. For parent events (no `parent` ref), `parent->field` resolves to null and `coalesce` returns the event's own value — no behaviour change.

`accessibilityInfo` is coalesced as the whole object (`{url, summary}`) rather than per subfield, so a parent's URL+summary aren't merged ambiguously with a partial child object.

## Scope

- Only `getEventBySlug` (event detail page query). Listing queries don't surface these fields.
- No schema, type, or component changes — the Astro page already reads `event.registration` etc.

## Test plan

- [x] `npm run build` clean
- [ ] Verify on deploy preview: a child event with no `registration` shows the parent's registration link
- [ ] Verify a child event with its own `registration` overrides the parent
- [ ] Verify a parent event still shows its own values unchanged