### PR TITLE
feat(event): hide supplementary links once event has ended

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -20,6 +20,8 @@ import {
   capitalise,
 } from '../../utils/eventUtils';
 import { PortableText } from 'astro-portabletext';
+import dayjs from '../../lib/dayjs';
+import { getEventEnd } from '../../utils/progressUtils';
 
 export const prerender = false;
 
@@ -122,23 +124,38 @@ const enumeratedChildTypes = (() => {
   return `${joined} at ${event.title}`;
 })();
 
-// Supplementary sidebar links
-const supplementaryLinks = [
-  event.registration && { href: event.registration, label: 'Registration' },
-  event.codeOfConduct && {
-    href: event.codeOfConduct,
-    label: 'Code of conduct',
-  },
-  event.accessibilityInfo?.url && {
-    href: event.accessibilityInfo.url,
-    label: 'Accessibility information',
-  },
-  event.schedule && { href: event.schedule, label: 'Schedule' },
-  event.callForSpeakersLink && {
-    href: event.callForSpeakersLink,
-    label: 'Call for speakers',
-  },
-].filter(Boolean) as Array<{ href: string; label: string }>;
+// Has the event ended? Used to hide supplementary links (registration,
+// schedule, etc.) once they're no longer relevant. Uses the same end-date
+// resolution as progressUtils.hasEnded() but without the showEnded gate,
+// which is a UI-context flag specific to the listing pages.
+const eventHasEnded = dayjs().isAfter(
+  getEventEnd({
+    dateStart: event.dateStart,
+    dateEnd: event.dateEnd,
+    timezone: event.timezone,
+    day: event.day,
+  })
+);
+
+// Supplementary sidebar links — hidden once the event has ended.
+const supplementaryLinks = eventHasEnded
+  ? []
+  : ([
+      event.registration && { href: event.registration, label: 'Registration' },
+      event.codeOfConduct && {
+        href: event.codeOfConduct,
+        label: 'Code of conduct',
+      },
+      event.accessibilityInfo?.url && {
+        href: event.accessibilityInfo.url,
+        label: 'Accessibility information',
+      },
+      event.schedule && { href: event.schedule, label: 'Schedule' },
+      event.callForSpeakersLink && {
+        href: event.callForSpeakersLink,
+        label: 'Call for speakers',
+      },
+    ].filter(Boolean) as Array<{ href: string; label: string }>);
 
 const hasSidebarLinks = supplementaryLinks.length > 0;
 


### PR DESCRIPTION
## Summary

- Once an event has ended, the supplementary sidebar links (Registration, Code of conduct, Accessibility information, Schedule, Call for speakers) are hidden.
- The primary "Event website" button stays — still useful for recordings, write-ups, archived materials.

## How

- Compute `eventHasEnded` using `getEventEnd()` from `src/utils/progressUtils.ts` (the existing canonical end-date resolver — handles `dateEnd`, fallback to end-of-day, timezone, all-day events).
- Did **not** reuse `hasEnded()` directly because it short-circuits on `!showEnded`, which is a listing-UI flag specific to the Today section. Detail page logic should not depend on it.
- When `eventHasEnded` is true, `supplementaryLinks` is `[]`, so `hasSidebarLinks` is `false` and the `<h2>Event resources</h2>` + `<ul>` collapse cleanly. The sidebar render condition `(event.website || event.organizer || hasSidebarLinks)` still keeps the website button.

## Caveats

- Pages are SSR with `Cache-Control: max-age=300, stale-while-revalidate=60`. Links may continue to appear for up to ~5 minutes after an event ends, then disappear on the next revalidation. Matches the existing caching tradeoff.
- For events without a `dateEnd`, `getEventEnd` falls back to end-of-day of `dateStart` in the event's timezone — so a single-day event hides its links the day after.

## Test plan

- [x] `npm run build` clean
- [ ] Verify on deploy preview: a clearly-past event's detail page shows the website button but no Registration/Schedule/etc. items
- [ ] Verify a future event still shows all supplementary links
- [ ] Verify a parent event whose dateEnd has passed hides the inherited links on its child events too (since coalesce + hide happens on the resolved values)