### PR TITLE
fix(event): span full width when no sidebar exists

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -446,7 +446,7 @@ const jsonLd = {
           )
         }
 
-        <div class="event-detail-main flow flow-m">
+        <div class={`event-detail-main flow flow-m${!event.website && !event.organizer && !hasSidebarLinks ? ' event-detail-main--full-width' : ''}`}>
           {
             (event.richDescription || event.description) && (
               <div class="event-detail__description flow">
@@ -679,6 +679,10 @@ const jsonLd = {
 
     .event-detail-main {
       max-width: 55rem;
+    }
+
+    .event-detail-main--full-width {
+      grid-column: 1 / -1;
     }
 
     .event-detail-sidebar {

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -446,7 +446,17 @@ const jsonLd = {
           )
         }
 
-        <div class={`event-detail-main flow flow-m${!event.website && !event.organizer && !hasSidebarLinks ? ' event-detail-main--full-width' : ''}`}>
+        <div
+          class:list={[
+            'event-detail-main',
+            'flow',
+            'flow-m',
+            {
+              'event-detail-main--full-width':
+                !event.website && !event.organizer && !hasSidebarLinks,
+            },
+          ]}
+        >
           {
             (event.richDescription || event.description) && (
               <div class="event-detail__description flow">


### PR DESCRIPTION
## Summary

- Theme events (e.g. ADHD Awareness Month) have no website, organiser, or supplementary links, so the sidebar `<aside>` is not rendered
- With the two-column grid layout, the main content div was placed in the narrow first column (18rem) instead of spanning the full width
- Adds `event-detail-main--full-width` class when there is no sidebar, with `grid-column: 1 / -1` to span both columns

## Before / After

Before: all content squashed into the left 18rem column on theme event pages  
After: content spans the full width when no sidebar is present

Fixes https://eventua11y.com/events/adhd-awareness-month-2026