### PR TITLE
chore: adopt Oxford spelling convention (-ize/-ization)

### DIFF
--- a/.agents/astro.md
+++ b/.agents/astro.md
@@ -31,7 +31,7 @@ Mid-tier (Claude Sonnet). Astro review is well-scoped and pattern-matching orien
 
 **SSR**: Pages not needing per-request data should prerender. Server-side fetching in frontmatter, not client components. No server-only imports in client code.
 
-**Components**: Astro for static, Vue only for interactivity. Check hydration directives. Avoid large prop serialisation.
+**Components**: Astro for static, Vue only for interactivity. Check hydration directives. Avoid large prop serialization.
 
 **Routing**: Dynamic routes validate params and 404 on invalid. Sitemap stays in sync.
 

--- a/.agents/coder.md
+++ b/.agents/coder.md
@@ -47,7 +47,7 @@ Mid-tier (Claude Sonnet). Feature implementation, bug fixes, and standard refact
 2. Follow existing patterns and conventions in the codebase.
 3. Run `npx astro check` after TypeScript changes to verify type safety.
 4. When the Lead provides Coder Requirements from a specialist, follow them precisely.
-5. Make only the requested changes. Do not refactor, rename, or reorganise code beyond the scope of the task.
+5. Make only the requested changes. Do not refactor, rename, or reorganize code beyond the scope of the task.
 
 ### Rules
 

--- a/.agents/lead.md
+++ b/.agents/lead.md
@@ -22,7 +22,7 @@ None — this is the top-level agent. If a task exceeds the team's capabilities 
 
 ## Instructions
 
-Before each delegation, explain which agent you are calling and why. After each agent returns, summarise what it found or did.
+Before each delegation, explain which agent you are calling and why. After each agent returns, summarize what it found or did.
 
 ### Specialist agents
 
@@ -59,14 +59,14 @@ Before each delegation, explain which agent you are calling and why. After each 
 3. Delegate implementation to `coder`.
 4. Delegate test writing to `tester` (functional) and/or `a11y-testing` (accessibility).
 5. After tests pass, invoke domain specialists to **review** the implementation.
-6. Synthesise findings into a unified report.
+6. Synthesize findings into a unified report.
 
 ### Cross-domain synthesis
 
 When collecting reports from multiple agents:
 
 1. **Deduplicate** — merge overlapping findings citing both perspectives.
-2. **Prioritise** — rank by severity: critical > serious > moderate > informational.
+2. **Prioritize** — rank by severity: critical > serious > moderate > informational.
 3. **Group by action** — cluster findings that affect the same file or feature.
 
 ### Rules

--- a/.agents/performance.md
+++ b/.agents/performance.md
@@ -2,7 +2,7 @@
 
 ## Role
 
-Reviews performance including Core Web Vitals, bundle size, caching strategies, hydration cost, image optimisation, and edge function efficiency. Diagnoses slowdowns. Answers performance questions.
+Reviews performance including Core Web Vitals, bundle size, caching strategies, hydration cost, image optimization, and edge function efficiency. Diagnoses slowdowns. Answers performance questions.
 
 ## Model
 

--- a/.agents/skills/designing-agent-teams/SKILL.md
+++ b/.agents/skills/designing-agent-teams/SKILL.md
@@ -50,7 +50,7 @@ Gather what is available from the codebase and the user's request. If the user h
 - Read the existing agent configuration files (check `.agents/`, `AGENTS.md`, and any platform-specific configs)
 - Identify which models are assigned where, what tools each agent has, scope definitions
 - Apply the review checklist (below) to identify issues
-- If the user has described specific pain points, prioritise those
+- If the user has described specific pain points, prioritize those
 
 ## Design the agent team
 
@@ -192,7 +192,7 @@ The lead should explain each handoff to the user: which agent is being called, w
 
 Add this to the lead's instructions:
 
-> Before each delegation, explain which agent you are calling and why. After each agent returns, summarise what it found or did.
+> Before each delegation, explain which agent you are calling and why. After each agent returns, summarize what it found or did.
 
 Reinforce this in any platform-specific config preamble so the lead sees it at invocation time, not just in its instruction file.
 

--- a/.agents/skills/fixing-accessibility-issues/SKILL.md
+++ b/.agents/skills/fixing-accessibility-issues/SKILL.md
@@ -9,7 +9,7 @@ description: >
   it, use `reviewing-accessibility` instead.
 ---
 
-Fix accessibility issues in implemented UI code. This skill takes findings from `reviewing-accessibility`, axe-core scans, or manual audits and produces code changes. It does not find new issues, estimate effort, prioritise, or write tests — use `reviewing-accessibility`, `estimating-accessibility-effort`, `prioritising-accessibility-fixes`, and `writing-accessibility-tests` for those.
+Fix accessibility issues in implemented UI code. This skill takes findings from `reviewing-accessibility`, axe-core scans, or manual audits and produces code changes. It does not find new issues, estimate effort, prioritize, or write tests — use `reviewing-accessibility`, `estimating-accessibility-effort`, `prioritising-accessibility-fixes`, and `writing-accessibility-tests` for those.
 
 ## Accept findings
 

--- a/.agents/skills/predicting-accessibility-risks/SKILL.md
+++ b/.agents/skills/predicting-accessibility-risks/SKILL.md
@@ -16,7 +16,7 @@ Before assessing risks, understand what is being proposed:
 1. **Read the plan** — feature description, user story, design document, technical spec, or conversation describing the intended change.
 2. **Read affected code** — if the change modifies existing UI, read the current implementation to understand what is already in place. Risks are relative to the starting point.
 3. **Identify the user interactions** — what will people do with this feature? List the verbs: navigate, filter, select, submit, drag, expand, dismiss, etc. Each interaction is a potential risk surface.
-4. **Identify the content** — what information does the feature present? Text, images, status indicators, data visualisations, real-time updates. Each content type has accessibility constraints.
+4. **Identify the content** — what information does the feature present? Text, images, status indicators, data visualizations, real-time updates. Each content type has accessibility constraints.
 
 ## Assess risks
 
@@ -62,7 +62,7 @@ Scale the approach to the project. Not every project has a research budget, but 
 
 **Solo and small projects** — test with a screen reader yourself (VoiceOver, NVDA, or TalkBack are free), ask a disabled friend or colleague to try key flows, post in accessibility communities for informal feedback, or use free single-session options from panel services. Even one person using assistive technology will reveal things automated checks cannot.
 
-**Teams with some research capacity** — include disabled participants in existing user research. The NHS benchmark of 1 person with access needs in every 5 research participants is a reasonable starting point. Recruit from disability organisations, charities, or internal staff disability networks.
+**Teams with some research capacity** — include disabled participants in existing user research. The NHS benchmark of 1 person with access needs in every 5 research participants is a reasonable starting point. Recruit from disability organizations, charities, or internal staff disability networks.
 
 **Dedicated accessibility research** — panel services like [Fable](https://makeitfable.com/), [Access Works](https://knowbility.org/programs/accessworks) (Knowbility), and [AbilityNet](https://abilitynet.org.uk/) provide pre-qualified participants with documented assistive technology configurations. This is the most reliable option for structured usability testing across multiple AT setups.
 
@@ -117,7 +117,7 @@ These are common risk areas, not exhaustive checklists. Use them as prompts to i
 - No screen reader indication of draggable items, drop targets, or current position
 - Move operations that rely solely on pointer position with no confirmation step
 
-### Data visualisation (charts, graphs, maps)
+### Data visualization (charts, graphs, maps)
 
 - No text alternative or data table for the information conveyed visually
 - Colour-only encoding (red/green for good/bad) excludes colour-blind users
@@ -169,7 +169,7 @@ These are common risk areas, not exhaustive checklists. Use them as prompts to i
 ### User research recommendations
 
 - Which risks would benefit most from validation with disabled users
-- What disability groups and AT configurations to prioritise in testing based on the risks identified
+- What disability groups and AT configurations to prioritize in testing based on the risks identified
 - At what development phase testing would be most valuable for each risk
 
 ### Recommendations
@@ -184,7 +184,7 @@ Omit empty risk levels. If there are no high risks, do not include an empty High
 - **Risk prediction is not a compliance audit.** The goal is to identify problems before they are built, not to produce a WCAG scorecard. A risk assessment that just lists WCAG criteria without connecting them to specific design decisions is not useful.
 - **Not every feature needs a full risk assessment.** A text content change, a colour tweak with verified contrast, or a change to backend logic with no UI impact may have zero accessibility risks. Say so rather than inventing risks.
 - **Component libraries reduce but do not eliminate risk.** Headless UI libraries (Base UI, Headless UI, Ark UI) handle many ARIA patterns correctly, but the risk shifts to composition — how components are assembled, what labels are provided, and how focus is managed between them.
-- **The most dangerous risks are structural, not superficial.** A missing alt text is easy to add later. A widget built without a keyboard interaction model requires a redesign. Prioritise structural risks over cosmetic ones.
+- **The most dangerous risks are structural, not superficial.** A missing alt text is easy to add later. A widget built without a keyboard interaction model requires a redesign. Prioritize structural risks over cosmetic ones.
 - **"We'll add accessibility later" is itself the highest risk.** If the plan defers accessibility to a future sprint, flag this explicitly. Retrofitting accessibility onto a finished feature is consistently and often significantly more expensive than building it in from the start.
 - **Consider the full range of disabilities.** Accessibility reviews disproportionately focus on screen reader users. Keyboard-only users, users with low vision (who may not use screen readers), users with cognitive disabilities, and users with motor impairments all have distinct needs. Name the affected group explicitly.
 - **Custom components carry more risk than standard HTML.** A `<button>` has built-in keyboard handling, focus management, and role. A `<div onClick>` has none of these. The more custom the implementation, the higher the risk.

--- a/.agents/skills/prioritising-accessibility-fixes/SKILL.md
+++ b/.agents/skills/prioritising-accessibility-fixes/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: prioritising-accessibility-fixes
-description: Use this skill to prioritise a set of accessibility issues for remediation based on severity, user impact, and effort. Triggers when triaging an accessibility backlog, deciding what to fix first after an audit, planning an accessibility sprint, or asking which accessibility issues matter most.
+description: Use this skill to prioritize a set of accessibility issues for remediation based on severity, user impact, and effort. Triggers when triaging an accessibility backlog, deciding what to fix first after an audit, planning an accessibility sprint, or asking which accessibility issues matter most.
 compatibility: Works best when issues already have effort estimates (from estimating-accessibility-effort) but can assess effort independently.
 ---
 
-# Prioritising Accessibility Fixes
+# Prioritizing Accessibility Fixes
 
-Given a set of accessibility issues, produce a prioritised remediation order based on severity, user impact, and effort. The output is a ranked list that helps decide what to fix first, what to batch together, and what can wait.
+Given a set of accessibility issues, produce a prioritized remediation order based on severity, user impact, and effort. The output is a ranked list that helps decide what to fix first, what to batch together, and what can wait.
 
-This skill works on a set of known issues. It does not find new issues (use `reviewing-accessibility` for that), estimate effort from scratch (use `estimating-accessibility-effort` for that, or provide estimates as input), or implement fixes (use `fixing-accessibility-issues` for that). If issues arrive without effort estimates, assess effort by reading the affected code before prioritising.
+This skill works on a set of known issues. It does not find new issues (use `reviewing-accessibility` for that), estimate effort from scratch (use `estimating-accessibility-effort` for that, or provide estimates as input), or implement fixes (use `fixing-accessibility-issues` for that). If issues arrive without effort estimates, assess effort by reading the affected code before prioritizing.
 
 ## Inputs
 
@@ -21,7 +21,7 @@ A set of accessibility issues, ideally with:
 - Effort estimate (XS / S / M / L / XL)
 - Reach (Systemic / Multi-page / Single page) — optional, most useful for projects with shared components
 
-If effort estimates are missing, read the affected code and estimate before prioritising. Do not prioritise without understanding effort — a "Critical" issue that takes 5 minutes should be fixed immediately, while a "Critical" issue requiring an architectural redesign needs different planning.
+If effort estimates are missing, read the affected code and estimate before prioritizing. Do not prioritize without understanding effort — a "Critical" issue that takes 5 minutes should be fixed immediately, while a "Critical" issue requiring an architectural redesign needs different planning.
 
 ### Effort sizes
 
@@ -153,7 +153,7 @@ After scoring all issues and assigning tiers, run a quick validation pass:
 ## Report format
 
 ```markdown
-## Accessibility Prioritisation - [scope]
+## Accessibility Prioritization - [scope]
 
 ### Tier 1 — Fix Immediately
 
@@ -200,7 +200,7 @@ If the project defines its own priority labels (e.g. P0–P3, Critical/High/Medi
 - **User impact requires judgment, not just WCAG mapping.** Two issues can both violate 2.1.1 (Keyboard) — one on the main navigation (High impact, every user on every page) and one on a settings toggle (Low impact, rare interaction). Same criterion, very different priority.
 - **Quick wins are disproportionately valuable.** A batch of 10 XS/S fixes might take less time than one L fix but improve accessibility across more pages and for more users. Always surface quick wins prominently.
 - **Do not defer all large items.** If the scoring model puts all L/XL items in Tier 3, the project will never fix structural accessibility problems. Ensure at least one L or XL item is scheduled in Tier 2 per planning cycle if structural issues exist.
-- **Priorities change.** A Tier 3 issue becomes Tier 1 when a user reports it, when a legal requirement emerges, or when a dependent fix promotes it. Revisit prioritisation periodically rather than treating it as a one-time exercise.
+- **Priorities change.** A Tier 3 issue becomes Tier 1 when a user reports it, when a legal requirement emerges, or when a dependent fix promotes it. Revisit prioritization periodically rather than treating it as a one-time exercise.
 - **Do not invent impact assessments.** If the project has analytics, use them — a page with 10,000 daily visits has higher impact than one with 10. If there are no analytics, assess based on the feature's centrality to the product's purpose, not assumptions about traffic.
 - **Accessibility debt compounds.** Five Moderate issues in the same component often indicate a pattern problem. Consider whether fixing the pattern (one M/L task) is more effective than five individual fixes.
 - **Scores are a decision aid, not a decision.** The model produces a number but cannot account for context it was not given — internal politics, upcoming redesigns, capacity constraints, or user research findings. Treat tier placement as a strong default that can be overridden with a stated reason.

--- a/.agents/skills/suggesting-next-steps/SKILL.md
+++ b/.agents/skills/suggesting-next-steps/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: suggesting-next-steps
-description: Use this skill to suggest prioritised next steps for a project. Triggers when the user asks what to work on next, wants to resume after a break, or needs help prioritising a backlog.
+description: Use this skill to suggest prioritized next steps for a project. Triggers when the user asks what to work on next, wants to resume after a break, or needs help prioritizing a backlog.
 compatibility: Requires file read access and gh CLI for GitHub issue/PR queries.
 ---
 
 # Suggesting Next Steps
 
-Analyse a project's current state and suggest prioritised next steps. This is a read-only skill — gather and organise information, do not make changes.
+Analyze a project's current state and suggest prioritized next steps. This is a read-only skill — gather and organize information, do not make changes.
 
 ## Gather context
 
@@ -49,7 +49,7 @@ When a tracking file exists, it is the primary source for what is done and what 
 - Look for obvious gaps: source files with no corresponding test files, test scripts that are defined but have no test files to run
 - Check CI status if GitHub Actions workflows exist: `gh run list --limit 5`
 
-## Categorise findings
+## Categorize findings
 
 Group what was found into five categories, presented in this order:
 
@@ -114,5 +114,5 @@ If there is genuinely nothing to suggest — the project is clean, tests pass, n
 - Do not make changes. This skill is strictly read-only — no commits, no file edits, no issue creation.
 - Not every repo uses GitHub. If there's no remote or `gh` fails, rely on local signals (git history, tracking files, project docs). Note the limitation but don't treat it as a blocker.
 - Tracking files vary in format. STATUS.md might use markdown headings, checklists, tables, or prose. Parse whatever structure exists rather than expecting a specific format.
-- Respect existing prioritisation. If the project has labelled issues (e.g., "Priority: High"), epics, or a phased roadmap, use that ordering rather than imposing a different one.
+- Respect existing prioritization. If the project has labelled issues (e.g., "Priority: High"), epics, or a phased roadmap, use that ordering rather than imposing a different one.
 - AGENTS.md describes the project and its agent team. Use it for context ("this is an accessibility audit tool" shapes what matters), but do not suggest agent team changes — that's a different skill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ The `lead` delegates to all other agents. No other agent delegates (flat hierarc
 3. Lead delegates to `coder` for implementation.
 4. Lead delegates to `tester` (functional) and/or `a11y-testing` (accessibility) for test authorship.
 5. After tests pass, Lead invokes specialists to **review** the implementation.
-6. Lead synthesises findings into a unified report.
+6. Lead synthesizes findings into a unified report.
 
 ### Escalation map
 
@@ -171,6 +171,17 @@ This project has two Sanity datasets: **`production`** and **`test`**.
 - **Never** create dummy, test, placeholder, or seed data in the `production` dataset. The production dataset contains only real, editorial content that powers the live site.
 - All test or dummy documents **must** be created in the **`test`** dataset.
 - When using Sanity MCP tools, always verify the `dataset` parameter before any write operation. If the data is for testing, experimentation, or development, set the dataset to `test`.
+
+## Spelling Convention
+
+This project uses **Oxford spelling** — the convention used by Oxford University Press, the OED, and many international organisations. Oxford spelling uses `-ize` and `-ization` endings (e.g. organize, organization, capitalize) while retaining other British conventions such as `-our` (colour), `-re` (centre), `-ence` (defence), and `-ogue` (catalogue).
+
+- **Do** write: analyze, organize, recognize, customize, capitalize, optimization, prioritize
+- **Don't** write: organise, recognise, customise, capitalise, optimisation, prioritise
+- **Keep British**: colour, favourite, centre, defence, catalogue
+- **Always `-ise`**: advise, comprise, surprise, exercise, supervise (these are not `-ize` words)
+
+Apply this convention to all user-facing content, code identifiers, comments, documentation, and agent instructions.
 
 ## Sub-Issues for Epics
 

--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import {
   getEventUrl,
   FORMAT_LABELS,
-  capitalise,
+  capitalize,
   getFormatPreposition,
 } from '../utils/eventUtils';
 import EventDate from './EventDate.vue';
@@ -59,7 +59,7 @@ const ended = computed(() => _hasEnded(now.value, progressOptions.value));
  * @returns {string} Human-readable format string
  */
 const displayFormat = computed(() =>
-  capitalise(FORMAT_LABELS[props.event.format] || props.event.format)
+  capitalize(FORMAT_LABELS[props.event.format] || props.event.format)
 );
 
 const formatPreposition = computed(() =>

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -16,7 +16,7 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
 
 <!doctype html>
 <html
-  lang="en"
+  lang="en-GB-oxendict"
   class="wa-brand-purple"
   data-flags-source={Astro.locals.flagsSource}
 >

--- a/src/layouts/error.astro
+++ b/src/layouts/error.astro
@@ -23,7 +23,7 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
 
 <!doctype html>
 <html
-  lang="en"
+  lang="en-GB-oxendict"
   class="wa-brand-purple"
   data-flags-source={Astro.locals.flagsSource}
 >

--- a/src/pages/curation-policy.astro
+++ b/src/pages/curation-policy.astro
@@ -73,8 +73,8 @@ import DefaultLayout from '../layouts/default.astro';
     <h2>Non-commercial focus</h2>
 
     <p>
-      Events should prioritise learning and community building over aggressive
-      sales or promotions. Commercial organisers and sponsors are fine, but
+      Events should prioritize learning and community building over aggressive
+      sales or promotions. Commercial organizers and sponsors are fine, but
       their involvement should align with the event's mission to educate and
       support the community.
     </p>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -17,7 +17,7 @@ import {
   isCallForSpeakersOpen,
   getFormatLabel,
   getFormatPreposition,
-  capitalise,
+  capitalize,
 } from '../../utils/eventUtils';
 import { PortableText } from 'astro-portabletext';
 import dayjs from '../../lib/dayjs';
@@ -76,7 +76,7 @@ const parentUrl = event.parentEvent?.slug?.current
   : undefined;
 // Format and speaker subtitle for child events (e.g. "Talk by Speaker Name")
 const displayFormat = getFormatLabel(event.format);
-const capitalisedFormat = displayFormat ? capitalise(displayFormat) : undefined;
+const capitalizedFormat = displayFormat ? capitalize(displayFormat) : undefined;
 const formatPreposition = getFormatPreposition(event.format);
 
 const isDedicatedToAccessibility =
@@ -278,7 +278,7 @@ const jsonLd = {
               <p aria-roledescription="subtitle" class="text-muted">
                 {displayFormat && (
                   <span>
-                    {capitalisedFormat}
+                    {capitalizedFormat}
                     {allSpeakers.length > 0 && (
                       <Fragment>
                         {' '}
@@ -364,7 +364,7 @@ const jsonLd = {
                       ) : (
                         event.parentEvent.title
                       )}
-                      {`, organised by `}
+                      {`, organized by `}
                       {event.organizer.website ? (
                         <a
                           href={event.organizer.website}
@@ -388,7 +388,7 @@ const jsonLd = {
                     </Fragment>
                   ) : event.organizer ? (
                     <Fragment>
-                      {`This event is organised by `}
+                      {`This event is organized by `}
                       {event.organizer.website ? (
                         <a
                           href={event.organizer.website}

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -466,7 +466,7 @@ describe('formatDateRange', () => {
     });
   });
 
-  describe('same-month date ranges (the key optimisation)', () => {
+  describe('same-month date ranges (the key optimization)', () => {
     it('deduplicates month and year for date-only ranges (en)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',

--- a/src/utils/eventUtils.test.ts
+++ b/src/utils/eventUtils.test.ts
@@ -9,7 +9,7 @@ import {
   compareByDateDesc,
   getFormatLabel,
   getFormatPreposition,
-  capitalise,
+  capitalize,
 } from './eventUtils';
 import type { Event, Book } from '../types/event';
 
@@ -444,20 +444,20 @@ describe('getFormatLabel', () => {
   });
 });
 
-// ── capitalise ─────────────────────────────────────────────────────────
+// ── capitalize ─────────────────────────────────────────────────────────
 
-describe('capitalise', () => {
-  it('capitalises the first letter', () => {
-    expect(capitalise('talk')).toBe('Talk');
-    expect(capitalise('workshop')).toBe('Workshop');
+describe('capitalize', () => {
+  it('capitalizes the first letter', () => {
+    expect(capitalize('talk')).toBe('Talk');
+    expect(capitalize('workshop')).toBe('Workshop');
   });
 
   it('preserves acronyms', () => {
-    expect(capitalise('Q&A')).toBe('Q&A');
+    expect(capitalize('Q&A')).toBe('Q&A');
   });
 
   it('handles empty string', () => {
-    expect(capitalise('')).toBe('');
+    expect(capitalize('')).toBe('');
   });
 });
 

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -208,9 +208,9 @@ export function getFormatLabel(format: string | undefined): string | undefined {
 }
 
 /**
- * Capitalises the first letter of a string.
+ * Capitalizes the first letter of a string.
  */
-export function capitalise(str: string): string {
+export function capitalize(str: string): string {
   if (!str) return str;
   return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -400,7 +400,10 @@ test.describe('Shared component accessibility', () => {
   });
 
   test('html element has lang attribute', async ({ page }) => {
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB-oxendict');
+    await expect(page.locator('html')).toHaveAttribute(
+      'lang',
+      'en-GB-oxendict'
+    );
   });
 });
 

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -400,7 +400,7 @@ test.describe('Shared component accessibility', () => {
   });
 
   test('html element has lang attribute', async ({ page }) => {
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB-oxendict');
   });
 });
 

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -87,7 +87,7 @@ test.describe('Event detail page', () => {
   });
 
   test('html element has lang attribute', async ({ page }) => {
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB-oxendict');
   });
 });
 

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -87,7 +87,10 @@ test.describe('Event detail page', () => {
   });
 
   test('html element has lang attribute', async ({ page }) => {
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en-GB-oxendict');
+    await expect(page.locator('html')).toHaveAttribute(
+      'lang',
+      'en-GB-oxendict'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Converts all British `-ise`/`-isation` spellings to Oxford `-ize`/`-ization` across UI content, code identifiers, tests, and agent instructions
- Renames `capitalise` → `capitalize` function and all references (eventUtils, tests, slug page, EventChild component)
- Adds a **Spelling Convention** section to `AGENTS.md` documenting the Oxford spelling standard for the project

No functional changes — all 276 unit tests pass.