### PR TITLE
Hide color mode switcher on mobile

### DIFF
--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -14,6 +14,24 @@
   }
 }
 
+.masthead__logo a {
+  display: block;
+  text-decoration: none;
+}
+
+.masthead__actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--p-space-xs);
+  margin-left: auto;
+}
+
+.masthead .logo {
+  color: var(--c-masthead-logo-color);
+  max-width: 12rem;
+}
+
 @media screen and (max-width: 580px) {
   .masthead .inner {
     align-items: center;
@@ -32,24 +50,6 @@
     justify-content: center;
     margin-left: 0;
   }
-}
-
-.masthead__logo a {
-  display: block;
-  text-decoration: none;
-}
-
-.masthead__actions {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--p-space-xs);
-  margin-left: auto;
-}
-
-.masthead .logo {
-  color: var(--c-masthead-logo-color);
-  max-width: 12rem;
 }
 
 .skip {

--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -22,6 +22,10 @@
   .masthead .inner .logo {
     margin-bottom: var(--p-space-s);
   }
+
+  #theme-selector {
+    display: none;
+  }
 }
 
 .masthead__logo a {

--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -29,6 +29,7 @@
   }
 
   .masthead__actions {
+    justify-content: center;
     margin-left: 0;
   }
 }

--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -16,6 +16,7 @@
 
 @media screen and (max-width: 580px) {
   .masthead .inner {
+    align-items: center;
     flex-direction: column;
   }
 

--- a/src/styles/_masthead.css
+++ b/src/styles/_masthead.css
@@ -26,6 +26,10 @@
   #theme-selector {
     display: none;
   }
+
+  .masthead__actions {
+    margin-left: 0;
+  }
 }
 
 .masthead__logo a {


### PR DESCRIPTION
The color mode switcher is hidden at the 580px mobile breakpoint, where the header stacks vertically and space is tight.

Adds `display: none` on `#theme-selector` inside the existing `@media screen and (max-width: 580px)` rule in `_masthead.css`.