### PR TITLE
Fix sub-event detail pages showing today's date when not yet scheduled

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -308,20 +308,22 @@ const jsonLd = {
           )
         }
 
-        {event.scheduled ? (
-          <EventDate
-            client:only="vue"
-            dateStart={event.dateStart}
-            dateEnd={event.dateEnd}
-            timezone={event.timezone}
-            day={event.day}
-            type={event.type}
-            showCountdown={true}
-            showEnded={true}
-          />
-        ) : (
-          <p class="text-muted">Not yet scheduled</p>
-        )}
+        {
+          event.scheduled ? (
+            <EventDate
+              client:only="vue"
+              dateStart={event.dateStart}
+              dateEnd={event.dateEnd}
+              timezone={event.timezone}
+              day={event.day}
+              type={event.type}
+              showCountdown={true}
+              showEnded={true}
+            />
+          ) : (
+            <p class="text-muted">Not yet scheduled</p>
+          )
+        }
 
         <EventDelivery
           client:idle

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -308,16 +308,20 @@ const jsonLd = {
           )
         }
 
-        <EventDate
-          client:only="vue"
-          dateStart={event.dateStart}
-          dateEnd={event.dateEnd}
-          timezone={event.timezone}
-          day={event.day}
-          type={event.type}
-          showCountdown={true}
-          showEnded={true}
-        />
+        {event.scheduled ? (
+          <EventDate
+            client:only="vue"
+            dateStart={event.dateStart}
+            dateEnd={event.dateEnd}
+            timezone={event.timezone}
+            day={event.day}
+            type={event.type}
+            showCountdown={true}
+            showEnded={true}
+          />
+        ) : (
+          <p class="text-muted">Not yet scheduled</p>
+        )}
 
         <EventDelivery
           client:idle


### PR DESCRIPTION
Sub-event detail pages (talks within a conference) were displaying today's date when their schedule hadn't been announced yet. This is because `dayjs(null)` returns the current date, and unscheduled sub-events have `dateStart: null` in Sanity.

Gates `<EventDate>` on `event.scheduled`, showing "Not yet scheduled" when false — the same pattern `EventChild.vue` already uses in listings.