### PR TITLE
Fix topic pages missing unscheduled sub-events

### DIFF
--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -335,7 +335,8 @@ export async function getTopicBySlug(slug: string): Promise<
         references(^._id) &&
         (
           (defined(dateEnd) && dateEnd >= now()) ||
-          (!defined(dateEnd) && dateStart >= now())
+          (!defined(dateEnd) && dateStart >= now()) ||
+          (scheduled == false && defined(parent) && parent->dateEnd >= now())
         )
       ] | order(dateStart asc) {
         _id,


### PR DESCRIPTION
Topic pages (e.g. /topics/aria) were missing talks that haven't been given a specific time slot yet. Unscheduled sub-events have no `dateStart` or `dateEnd`, so the existing date filter excluded them entirely.

Adds a third condition to the GROQ filter in `getTopicBySlug` that matches events where `scheduled == false` and the parent event is still upcoming.