### PR TITLE
Show event date when dateStart is set, regardless of scheduled flag

### DIFF
--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -96,9 +96,8 @@ const speakersList = computed(() => {
     </div>
 
     <div class="event__meta">
-      <template v-if="event.scheduled">
+      <template v-if="event.dateStart">
         <EventDate
-          v-if="event.dateStart"
           :dateStart="event.dateStart"
           :dateEnd="event.dateEnd"
           :timezone="event.timezone"

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -309,7 +309,7 @@ const jsonLd = {
         }
 
         {
-          event.scheduled ? (
+          event.dateStart ? (
             <EventDate
               client:only="vue"
               dateStart={event.dateStart}


### PR DESCRIPTION
Some events (e.g. [Nystagmus Awareness Day 2026](https://eventua11y.com/events/nystagmus-awareness-day-2026)) displayed "Not yet scheduled" even though they have a confirmed date. This made scheduled events look unscheduled to visitors. The fix means an event's date now shows whenever one is set.

The detail page and `EventChild` component gated date display on the `scheduled` boolean. That flag is `null` on 96 published events that have a real `dateStart`, so all of them rendered "Not yet scheduled" despite being scheduled. The `scheduled` flag's actual purpose (per the topic query in `src/lib/sanity.ts`) is to mark child events that inherit their date from a parent — it was never meant to suppress a date that is genuinely present.

- `src/pages/events/[slug].astro`: key date display off `event.dateStart` instead of `event.scheduled`.
- `src/components/EventChild.vue`: same change; the inner `EventDate` already required `dateStart`, so the `scheduled` wrapper was redundant.

`EventDate` already handles the affected event's `null` timezone and all-day flag (defaults to UTC/international), so no further changes were needed. No CMS data was edited — the unset-flag state is the norm across the dataset, so correcting the rendering logic fixes all affected events and prevents recurrence.