### PR TITLE
Fix skip link sending focus to the header

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -127,7 +127,7 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
 
     <TheHeader />
 
-    <main id="main">
+    <main id="main" tabindex="-1">
       <slot />
     </main>
 

--- a/src/layouts/error.astro
+++ b/src/layouts/error.astro
@@ -142,7 +142,7 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
       </div>
     </header>
 
-    <main id="main">
+    <main id="main" tabindex="-1">
       <slot />
     </main>
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -91,6 +91,12 @@ wa-switch:focus-within::part(control) {
   scroll-margin-top: 7rem;
 }
 
+/* Skip-link target: focusable via tabindex="-1" but not a visible focus ring
+   around the whole content region */
+#main:focus {
+  outline: none;
+}
+
 .content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What this does

The "Skip to main content" link looked broken: instead of jumping to the page content, it appeared to land on the header. This fixes it so the link does what it says, moving you straight to the main content.

## Why it happened

The skip link points at `<main id="main">`. A `<main>` element isn't focusable on its own, so clicking the link scrolled the page but never actually moved keyboard focus. The very next Tab press then went to the first real focusable thing in the page, which is the header navigation. That's why it looked like the skip link was "linking to the header".

## The fix

- Add `tabindex="-1"` to `<main id="main">` in both `default.astro` and `error.astro` so focus moves to the content region when the skip link is used.
- Suppress the focus outline on the `#main` container so a tabindex target doesn't draw a ring around the whole content area. It's only programmatically focusable, never in the tab order.