### PR TITLE
feat(events): show event hashtags in sidebar

### DIFF
--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -143,6 +143,7 @@ const faKitCode = import.meta.env.FA_KIT_CODE || '';
   import '@awesome.me/webawesome/dist/components/button/button.js';
   import '@awesome.me/webawesome/dist/components/callout/callout.js';
   import '@awesome.me/webawesome/dist/components/card/card.js';
+  import '@awesome.me/webawesome/dist/components/copy-button/copy-button.js';
   import '@awesome.me/webawesome/dist/components/divider/divider.js';
   import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
   import '@awesome.me/webawesome/dist/components/dropdown/dropdown.js';

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -179,6 +179,7 @@ export async function getEventBySlug(slug: string): Promise<Event | null> {
       "callForSpeakersLink": coalesce(callForSpeakersLink, parent->callForSpeakersLink),
       "attendanceMode": coalesce(attendanceMode, parent->attendanceMode),
       "location": coalesce(location, parent->location),
+      "hashtags": coalesce(hashtags, parent->hashtags),
       "parentEvent": parent->{ title, slug },
       "speakers": speakers[]->{ _id, name },
       "organizer": coalesce(organizer, parent->organizer)->{ _id, name, website },

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -73,6 +73,7 @@ interface RawEvent {
     slug: { current: string };
     description?: string;
   }>;
+  hashtags?: string[];
 }
 
 /**

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -50,6 +50,13 @@ if (Array.isArray(event.speakers)) {
   );
 }
 
+const hashtags = Array.isArray(event.hashtags)
+  ? event.hashtags.filter(
+      (t): t is string => typeof t === 'string' && t.trim().length > 0
+    )
+  : [];
+const hasHashtags = hashtags.length > 0;
+
 // Cache the response to reduce Sanity API calls, matching the
 // strategy used by the get-events edge function.
 Astro.response.headers.set(
@@ -358,7 +365,10 @@ const jsonLd = {
 
       <div class="event-detail-body">
         {
-          (event.website || event.organizer || hasSidebarLinks) && (
+          (event.website ||
+            event.organizer ||
+            hasSidebarLinks ||
+            hasHashtags) && (
             <aside class="event-detail-sidebar">
               <wa-card class="event-detail-sidebar__card" appearance="outlined">
                 <p>
@@ -447,6 +457,12 @@ const jsonLd = {
                     </ul>
                   </>
                 )}
+                {hasHashtags && (
+                  <p class="event-detail-sidebar__hashtags">
+                    Use these hashtags:{' '}
+                    {hashtags.map((tag) => `#${tag}`).join(', ')}
+                  </p>
+                )}
               </wa-card>
             </aside>
           )
@@ -459,7 +475,10 @@ const jsonLd = {
             'flow-m',
             {
               'event-detail-main--full-width':
-                !event.website && !event.organizer && !hasSidebarLinks,
+                !event.website &&
+                !event.organizer &&
+                !hasSidebarLinks &&
+                !hasHashtags,
             },
           ]}
         >
@@ -679,6 +698,10 @@ const jsonLd = {
     display: inline-flex;
     align-items: center;
     gap: var(--p-space-3xs);
+  }
+
+  .event-detail-sidebar__hashtags {
+    margin-top: var(--p-space-xs);
   }
 
   @media (min-width: 769px) {

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -423,7 +423,7 @@ const jsonLd = {
                     <Fragment>
                       {' '}
                       Refer to the official event website for the most accurate
-                      and up-to-date information.
+                      information.
                     </Fragment>
                   )}
                 </p>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -458,10 +458,22 @@ const jsonLd = {
                   </>
                 )}
                 {hasHashtags && (
-                  <p class="event-detail-sidebar__hashtags">
-                    Use these hashtags:{' '}
-                    {hashtags.map((tag) => `#${tag}`).join(', ')}
-                  </p>
+                  <>
+                    <h2 class="event-detail-sidebar__hashtags-heading">
+                      Hashtags
+                    </h2>
+                    <ul role="list" class="event-detail-sidebar__hashtags">
+                      {hashtags.map((tag) => (
+                        <li class="event-detail-sidebar__hashtag">
+                          <span>{`#${tag}`}</span>
+                          <wa-copy-button
+                            value={`#${tag}`}
+                            copy-label={`Copy #${tag}`}
+                          />
+                        </li>
+                      ))}
+                    </ul>
+                  </>
                 )}
               </wa-card>
             </aside>
@@ -700,8 +712,28 @@ const jsonLd = {
     gap: var(--p-space-3xs);
   }
 
+  .event-detail-sidebar__hashtags-heading {
+    margin: var(--p-space-s) 0 var(--p-space-3xs);
+    font-size: var(--p-step--1);
+  }
+
   .event-detail-sidebar__hashtags {
-    margin-top: var(--p-space-xs);
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--p-space-2xs);
+  }
+
+  .event-detail-sidebar__hashtag {
+    display: flex;
+    align-items: center;
+    gap: var(--p-space-3xs);
+  }
+
+  .event-detail-sidebar__hashtag span {
+    flex: 1 1 auto;
   }
 
   @media (min-width: 769px) {

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -723,7 +723,7 @@ const jsonLd = {
     margin: 0;
     display: flex;
     flex-direction: column;
-    gap: var(--p-space-2xs);
+    gap: 0;
   }
 
   .event-detail-sidebar__hashtag {

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -65,6 +65,7 @@ export interface Event {
   speakers?: Speaker[];
   organizer?: Organizer;
   topics?: TopicSummary[];
+  hashtags?: string[];
 }
 
 export interface ChildEvent {

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -304,10 +304,11 @@ test.describe('Curation Policy page accessibility', () => {
 // ---------------------------------------------------------------------------
 // Event detail page with hashtags (/events/all-things-open-2026)
 // ---------------------------------------------------------------------------
-// Covers the sidebar <wa-card> that renders plain-text hashtags. The axe scan
-// catches contrast issues; the targeted assertion confirms the hashtag tokens
-// (including the # prefix) are present in the DOM and announced to screen
-// readers as plain text.
+// Covers the sidebar <wa-card> that renders hashtags as a labelled group of
+// copy buttons. The axe scan catches contrast issues and validates each copy
+// button's accessible name (from copy-label, which axe reads through shadow
+// DOM); the targeted assertion confirms the # tokens are present and the copy
+// buttons are labelled.
 test.describe('Event detail page (with hashtags) accessibility', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/events/all-things-open-2026');
@@ -319,15 +320,19 @@ test.describe('Event detail page (with hashtags) accessibility', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('hashtags paragraph is present and contains # tokens as plain text', async ({
+  test('hashtags render with # tokens and labelled copy buttons', async ({
     page,
   }) => {
     // The # symbol is intentionally visible and announced — it identifies
-    // the tokens as hashtags. Confirm it is not hidden or stripped.
-    const hashtagsPara = page.locator('.event-detail-sidebar__hashtags');
-    await expect(hashtagsPara).toBeVisible();
-    await expect(hashtagsPara).toContainText('#AllThingsOpen');
-    await expect(hashtagsPara).toContainText('#ATO2026');
+    // the tokens as hashtags. Each tag has a copy button whose accessible
+    // name comes from copy-label.
+    const items = page.locator('.event-detail-sidebar__hashtag');
+    await expect(items.nth(0)).toContainText('#AllThingsOpen');
+    await expect(items.nth(1)).toContainText('#ATO2026');
+    const buttons = page.locator(
+      '.event-detail-sidebar__hashtag wa-copy-button'
+    );
+    await expect(buttons.nth(0)).toHaveAttribute('copy-label', /Copy #/);
   });
 });
 

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -302,6 +302,36 @@ test.describe('Curation Policy page accessibility', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Event detail page with hashtags (/events/all-things-open-2026)
+// ---------------------------------------------------------------------------
+// Covers the sidebar <wa-card> that renders plain-text hashtags. The axe scan
+// catches contrast issues; the targeted assertion confirms the hashtag tokens
+// (including the # prefix) are present in the DOM and announced to screen
+// readers as plain text.
+test.describe('Event detail page (with hashtags) accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/events/all-things-open-2026');
+    await page.waitForSelector('.event-detail-sidebar__hashtags');
+  });
+
+  test('has no WCAG 2.2 AA violations', async ({ page }) => {
+    const results = await runAxeScan(page);
+    expect(results.violations).toEqual([]);
+  });
+
+  test('hashtags paragraph is present and contains # tokens as plain text', async ({
+    page,
+  }) => {
+    // The # symbol is intentionally visible and announced — it identifies
+    // the tokens as hashtags. Confirm it is not hidden or stripped.
+    const hashtagsPara = page.locator('.event-detail-sidebar__hashtags');
+    await expect(hashtagsPara).toBeVisible();
+    await expect(hashtagsPara).toContainText('#AllThingsOpen');
+    await expect(hashtagsPara).toContainText('#ATO2026');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 404 Page (/404)
 // ---------------------------------------------------------------------------
 test.describe('404 page accessibility', () => {
@@ -419,6 +449,11 @@ const pages = [
   { name: 'Accessibility Statement', path: '/accessibility' },
   { name: 'Curation Policy', path: '/curation-policy' },
   { name: '404', path: '/404' },
+  {
+    name: 'Event detail (with hashtags)',
+    path: '/events/all-things-open-2026',
+    waitSelector: '.event-detail-sidebar__hashtags',
+  },
 ];
 
 for (const colorScheme of ['light', 'dark'] as const) {

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -107,7 +107,9 @@ test.describe('Event detail page - sidebar hashtags', () => {
     await expect(hashtags).toBeVisible();
   });
 
-  test('hashtags paragraph begins with the expected label', async ({ page }) => {
+  test('hashtags paragraph begins with the expected label', async ({
+    page,
+  }) => {
     const hashtags = page.locator('.event-detail-sidebar__hashtags');
     await expect(hashtags).toContainText('Use these hashtags:');
   });

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -138,12 +138,18 @@ test.describe('Event detail page - sidebar hashtags', () => {
     );
   });
 
-  test('hashtags list is the last element inside the sidebar card', async ({
+  test('hashtags list is the last section inside the sidebar card', async ({
     page,
   }) => {
-    const card = page.locator('.event-detail-sidebar__card');
-    const lastChild = card.locator('> *:last-child');
-    await expect(lastChild).toHaveClass(/event-detail-sidebar__hashtags/);
+    // Inspect the card's light-DOM children directly. A CSS '> *:last-child'
+    // locator pierces the wa-card shadow DOM and also matches its internal
+    // <footer part="footer">, so use evaluate to stay in the light DOM.
+    const lastChildClass = await page.evaluate(() => {
+      const card = document.querySelector('.event-detail-sidebar__card');
+      const children = card ? Array.from(card.children) : [];
+      return children.at(-1)?.className ?? '';
+    });
+    expect(lastChildClass).toContain('event-detail-sidebar__hashtags');
   });
 });
 

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -94,6 +94,63 @@ test.describe('Event detail page', () => {
   });
 });
 
+// Slug stable in both production and test datasets; hashtags: ["AllThingsOpen", "ATO2026"]
+const HASHTAG_SLUG = 'all-things-open-2026';
+
+test.describe('Event detail page - sidebar hashtags', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/events/${HASHTAG_SLUG}`);
+  });
+
+  test('sidebar hashtags paragraph is present', async ({ page }) => {
+    const hashtags = page.locator('.event-detail-sidebar__hashtags');
+    await expect(hashtags).toBeVisible();
+  });
+
+  test('hashtags paragraph begins with the expected label', async ({ page }) => {
+    const hashtags = page.locator('.event-detail-sidebar__hashtags');
+    await expect(hashtags).toContainText('Use these hashtags:');
+  });
+
+  test('hashtags paragraph contains at least one #-prefixed token', async ({
+    page,
+  }) => {
+    const hashtags = page.locator('.event-detail-sidebar__hashtags');
+    const text = await hashtags.textContent();
+    // Resilient pattern: label followed by at least one word-character after '#'
+    expect(text).toMatch(/Use these hashtags:\s*#\w/);
+  });
+
+  test('hashtags paragraph contains the specific event hashtags', async ({
+    page,
+  }) => {
+    // These values come from Sanity editorial content and could change if the
+    // event record is updated.
+    const hashtags = page.locator('.event-detail-sidebar__hashtags');
+    await expect(hashtags).toContainText('#AllThingsOpen');
+    await expect(hashtags).toContainText('#ATO2026');
+  });
+
+  test('multiple hashtags are comma-separated with no trailing comma', async ({
+    page,
+  }) => {
+    const hashtags = page.locator('.event-detail-sidebar__hashtags');
+    const text = await hashtags.textContent();
+    // The two tags should be joined by ', ' with no trailing comma
+    expect(text).toContain('#AllThingsOpen, #ATO2026');
+    expect(text).not.toMatch(/,\s*$/);
+  });
+
+  test('hashtags paragraph is the last element inside the sidebar card', async ({
+    page,
+  }) => {
+    // The sidebar card is a wa-card; select its last direct paragraph child
+    const card = page.locator('.event-detail-sidebar__card');
+    const lastChild = card.locator('> p:last-child');
+    await expect(lastChild).toHaveClass(/event-detail-sidebar__hashtags/);
+  });
+});
+
 test.describe('Event detail page - 404 handling', () => {
   test('non-existent slug redirects to 404', async ({ page }) => {
     const response = await page.goto('/events/this-event-does-not-exist-12345');

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -102,53 +102,47 @@ test.describe('Event detail page - sidebar hashtags', () => {
     await page.goto(`/events/${HASHTAG_SLUG}`);
   });
 
-  test('sidebar hashtags paragraph is present', async ({ page }) => {
+  test('sidebar hashtags list is present', async ({ page }) => {
     const hashtags = page.locator('.event-detail-sidebar__hashtags');
     await expect(hashtags).toBeVisible();
   });
 
-  test('hashtags paragraph begins with the expected label', async ({
-    page,
-  }) => {
-    const hashtags = page.locator('.event-detail-sidebar__hashtags');
-    await expect(hashtags).toContainText('Use these hashtags:');
+  test('hashtags group has a "Hashtags" heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Hashtags' })).toBeVisible();
   });
 
-  test('hashtags paragraph contains at least one #-prefixed token', async ({
-    page,
-  }) => {
-    const hashtags = page.locator('.event-detail-sidebar__hashtags');
-    const text = await hashtags.textContent();
-    // Resilient pattern: label followed by at least one word-character after '#'
-    expect(text).toMatch(/Use these hashtags:\s*#\w/);
-  });
-
-  test('hashtags paragraph contains the specific event hashtags', async ({
+  test('each hashtag renders as a list item with the # prefix', async ({
     page,
   }) => {
     // These values come from Sanity editorial content and could change if the
     // event record is updated.
-    const hashtags = page.locator('.event-detail-sidebar__hashtags');
-    await expect(hashtags).toContainText('#AllThingsOpen');
-    await expect(hashtags).toContainText('#ATO2026');
+    const items = page.locator('.event-detail-sidebar__hashtag');
+    await expect(items).toHaveCount(2);
+    await expect(items.nth(0)).toContainText('#AllThingsOpen');
+    await expect(items.nth(1)).toContainText('#ATO2026');
   });
 
-  test('multiple hashtags are comma-separated with no trailing comma', async ({
+  test('each hashtag has a copy button that copies the tag with its #', async ({
     page,
   }) => {
-    const hashtags = page.locator('.event-detail-sidebar__hashtags');
-    const text = await hashtags.textContent();
-    // The two tags should be joined by ', ' with no trailing comma
-    expect(text).toContain('#AllThingsOpen, #ATO2026');
-    expect(text).not.toMatch(/,\s*$/);
+    const buttons = page.locator(
+      '.event-detail-sidebar__hashtag wa-copy-button'
+    );
+    await expect(buttons).toHaveCount(2);
+    // The copied value includes the leading # so it is paste-ready, and
+    // copy-label supplies the button's accessible name.
+    await expect(buttons.nth(0)).toHaveAttribute('value', '#AllThingsOpen');
+    await expect(buttons.nth(0)).toHaveAttribute(
+      'copy-label',
+      'Copy #AllThingsOpen'
+    );
   });
 
-  test('hashtags paragraph is the last element inside the sidebar card', async ({
+  test('hashtags list is the last element inside the sidebar card', async ({
     page,
   }) => {
-    // The sidebar card is a wa-card; select its last direct paragraph child
     const card = page.locator('.event-detail-sidebar__card');
-    const lastChild = card.locator('> p:last-child');
+    const lastChild = card.locator('> *:last-child');
     await expect(lastChild).toHaveClass(/event-detail-sidebar__hashtags/);
   });
 });


### PR DESCRIPTION
Events can now record the hashtags their organizers use on social media (added in the Sanity schema in eventua11y/eventua11y-sanity#270). This shows them on the event page so visitors know which tags to use when posting about an event.

They appear in the sidebar below the resource links as "Use these hashtags: #tag, #tag", shown only when an event has hashtags set.