### PR TITLE
fix(events): remove stray spacing above sidebar Hashtags heading

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -166,6 +166,15 @@ const supplementaryLinks = eventHasEnded
 
 const hasSidebarLinks = supplementaryLinks.length > 0;
 
+// The sidebar intro paragraph only has content when there is an organizer, a
+// parent event, or a website. Without this guard an empty <p> would render and
+// push the sidebar sections below it (e.g. Hashtags) down with stray spacing.
+const hasSidebarIntro = !!(
+  event.organizer ||
+  (isChildEvent && event.parentEvent) ||
+  event.website
+);
+
 // JSON-LD structured data
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -371,110 +380,117 @@ const jsonLd = {
             hasHashtags) && (
             <aside class="event-detail-sidebar">
               <wa-card class="event-detail-sidebar__card" appearance="outlined">
-                <p>
-                  {isChildEvent && event.parentEvent && event.organizer ? (
-                    <Fragment>
-                      This event is part of{' '}
-                      {parentUrl ? (
-                        <a href={parentUrl}>{event.parentEvent.title}</a>
+                <div class="event-detail-sidebar__content flow flow-s">
+                  {hasSidebarIntro && (
+                    <p>
+                      {isChildEvent && event.parentEvent && event.organizer ? (
+                        <Fragment>
+                          This event is part of{' '}
+                          {parentUrl ? (
+                            <a href={parentUrl}>{event.parentEvent.title}</a>
+                          ) : (
+                            event.parentEvent.title
+                          )}
+                          {`, organized by `}
+                          {event.organizer.website ? (
+                            <a
+                              href={event.organizer.website}
+                              rel="noopener noreferrer"
+                              set:text={event.organizer.name}
+                            />
+                          ) : (
+                            event.organizer.name
+                          )}
+                          {`.`}
+                        </Fragment>
+                      ) : isChildEvent && event.parentEvent ? (
+                        <Fragment>
+                          This event is part of{' '}
+                          {parentUrl ? (
+                            <a href={parentUrl}>{event.parentEvent.title}</a>
+                          ) : (
+                            event.parentEvent.title
+                          )}
+                          .
+                        </Fragment>
+                      ) : event.organizer ? (
+                        <Fragment>
+                          {`This event is organized by `}
+                          {event.organizer.website ? (
+                            <a
+                              href={event.organizer.website}
+                              rel="noopener noreferrer"
+                              set:text={event.organizer.name}
+                            />
+                          ) : (
+                            event.organizer.name
+                          )}
+                          {`.`}
+                        </Fragment>
                       ) : (
-                        event.parentEvent.title
+                        ''
                       )}
-                      {`, organized by `}
-                      {event.organizer.website ? (
-                        <a
-                          href={event.organizer.website}
-                          rel="noopener noreferrer"
-                          set:text={event.organizer.name}
-                        />
-                      ) : (
-                        event.organizer.name
+                      {event.website && (
+                        <Fragment>
+                          {' '}
+                          Refer to the official event website for the most
+                          accurate information.
+                        </Fragment>
                       )}
-                      {`.`}
-                    </Fragment>
-                  ) : isChildEvent && event.parentEvent ? (
-                    <Fragment>
-                      This event is part of{' '}
-                      {parentUrl ? (
-                        <a href={parentUrl}>{event.parentEvent.title}</a>
-                      ) : (
-                        event.parentEvent.title
-                      )}
-                      .
-                    </Fragment>
-                  ) : event.organizer ? (
-                    <Fragment>
-                      {`This event is organized by `}
-                      {event.organizer.website ? (
-                        <a
-                          href={event.organizer.website}
-                          rel="noopener noreferrer"
-                          set:text={event.organizer.name}
-                        />
-                      ) : (
-                        event.organizer.name
-                      )}
-                      {`.`}
-                    </Fragment>
-                  ) : (
-                    ''
+                    </p>
                   )}
                   {event.website && (
-                    <Fragment>
-                      {' '}
-                      Refer to the official event website for the most accurate
-                      information.
-                    </Fragment>
+                    <wa-button
+                      href={event.website}
+                      rel="external"
+                      variant="neutral"
+                      appearance="accent"
+                      style="width: 100%;"
+                      class="event-detail-sidebar__website-button"
+                    >
+                      Event website
+                      <span class="sr-only"> (opens external site)</span>
+                      <wa-icon slot="end" name="arrow-up-right-from-square" />
+                    </wa-button>
                   )}
-                </p>
-                {event.website && (
-                  <wa-button
-                    href={event.website}
-                    rel="external"
-                    variant="neutral"
-                    appearance="accent"
-                    style="width: 100%;"
-                    class="event-detail-sidebar__website-button"
-                  >
-                    Event website
-                    <span class="sr-only"> (opens external site)</span>
-                    <wa-icon slot="end" name="arrow-up-right-from-square" />
-                  </wa-button>
-                )}
-                {hasSidebarLinks && (
-                  <>
-                    <h2 class="sr-only">Event resources</h2>
-                    <ul role="list" class="event-detail-sidebar__links">
-                      {supplementaryLinks.map((link) => (
-                        <li>
-                          <a href={link.href} rel="external">
-                            {link.label}
-                            <span class="sr-only"> (opens external site)</span>
-                            <wa-icon name="arrow-up-right-from-square" />
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </>
-                )}
-                {hasHashtags && (
-                  <>
-                    <h2 class="event-detail-sidebar__hashtags-heading">
-                      Hashtags
-                    </h2>
-                    <ul role="list" class="event-detail-sidebar__hashtags">
-                      {hashtags.map((tag) => (
-                        <li class="event-detail-sidebar__hashtag">
-                          <span>{`#${tag}`}</span>
-                          <wa-copy-button
-                            value={`#${tag}`}
-                            copy-label={`Copy #${tag}`}
-                          />
-                        </li>
-                      ))}
-                    </ul>
-                  </>
-                )}
+                  {hasSidebarLinks && (
+                    <div class="flow flow-3xs">
+                      <h2 class="sr-only">Event resources</h2>
+                      <ul role="list" class="event-detail-sidebar__links">
+                        {supplementaryLinks.map((link) => (
+                          <li>
+                            <a href={link.href} rel="external">
+                              {link.label}
+                              <span class="sr-only">
+                                {' '}
+                                (opens external site)
+                              </span>
+                              <wa-icon name="arrow-up-right-from-square" />
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {hasHashtags && (
+                    <div class="event-detail-sidebar__hashtags-group flow flow-3xs">
+                      <h2 class="event-detail-sidebar__hashtags-heading">
+                        Hashtags
+                      </h2>
+                      <ul role="list" class="event-detail-sidebar__hashtags">
+                        {hashtags.map((tag) => (
+                          <li class="event-detail-sidebar__hashtag">
+                            <span>{`#${tag}`}</span>
+                            <wa-copy-button
+                              value={`#${tag}`}
+                              copy-label={`Copy #${tag}`}
+                            />
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
               </wa-card>
             </aside>
           )
@@ -693,14 +709,9 @@ const jsonLd = {
     font-size: var(--p-step--1);
   }
 
-  .event-detail-sidebar__website-button {
-    margin-top: var(--p-space-xs);
-  }
-
   .event-detail-sidebar__links {
     list-style: none;
     padding: 0;
-    margin-top: var(--p-space-xs);
     display: flex;
     flex-direction: column;
     gap: var(--p-space-2xs);
@@ -713,14 +724,13 @@ const jsonLd = {
   }
 
   .event-detail-sidebar__hashtags-heading {
-    margin: var(--p-space-s) 0 var(--p-space-3xs);
+    margin: 0;
     font-size: var(--p-step--1);
   }
 
   .event-detail-sidebar__hashtags {
     list-style: none;
     padding: 0;
-    margin: 0;
     display: flex;
     flex-direction: column;
     gap: 0;

--- a/tests/event-page.spec.ts
+++ b/tests/event-page.spec.ts
@@ -138,18 +138,18 @@ test.describe('Event detail page - sidebar hashtags', () => {
     );
   });
 
-  test('hashtags list is the last section inside the sidebar card', async ({
+  test('hashtags group is the last section inside the sidebar card', async ({
     page,
   }) => {
-    // Inspect the card's light-DOM children directly. A CSS '> *:last-child'
-    // locator pierces the wa-card shadow DOM and also matches its internal
-    // <footer part="footer">, so use evaluate to stay in the light DOM.
+    // Inspect the light-DOM children of the card's content wrapper. A CSS
+    // '> *:last-child' locator would pierce the wa-card shadow DOM and also
+    // match its internal <footer part="footer">, so use evaluate instead.
     const lastChildClass = await page.evaluate(() => {
-      const card = document.querySelector('.event-detail-sidebar__card');
-      const children = card ? Array.from(card.children) : [];
+      const content = document.querySelector('.event-detail-sidebar__content');
+      const children = content ? Array.from(content.children) : [];
       return children.at(-1)?.className ?? '';
     });
-    expect(lastChildClass).toContain('event-detail-sidebar__hashtags');
+    expect(lastChildClass).toContain('event-detail-sidebar__hashtags-group');
   });
 });
 


### PR DESCRIPTION
On events that have hashtags but nothing else in the sidebar panel (no website, organizer, or resource links), the "Hashtags" heading showed an odd gap above it. Example: https://eventua11y.com/events/international-week-of-deaf-people

The sidebar card now spaces its sections with the existing flow utility instead of hand-placed margins, so the first section sits flush at the top regardless of what's present, and the empty intro paragraph is no longer rendered.