### PR TITLE
Show live local time in Today section

### DIFF
--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -7,7 +7,6 @@
           <time class="text-muted" :datetime="today.format('YYYY-MM-DD')">{{
             today.format('MMMM D, YYYY')
           }}</time>
-          <span class="text-muted" aria-hidden="true">·</span>
           <time class="text-muted" :datetime="now.format('HH:mm')">{{
             currentTime
           }}</time>
@@ -108,7 +107,7 @@ watch(
 .today__subtitle {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5ch;
+  gap: 1ch;
 }
 
 .events {

--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -3,9 +3,13 @@
     <div class="container flow">
       <hgroup role="group" aria-roledescription="Heading group">
         <h2>Today</h2>
-        <p aria-roledescription="subtitle">
+        <p aria-roledescription="subtitle" class="today__subtitle">
           <time class="text-muted" :datetime="today.format('YYYY-MM-DD')">{{
             today.format('MMMM D, YYYY')
+          }}</time>
+          <span class="text-muted" aria-hidden="true">·</span>
+          <time class="text-muted" :datetime="now.format('HH:mm')">{{
+            currentTime
           }}</time>
         </p>
       </hgroup>
@@ -37,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, watch } from 'vue';
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue';
 import userStore from '../store/userStore';
 import dayjs from '../lib/dayjs';
 import Event from './Event.vue';
@@ -48,6 +52,18 @@ const today = computed(() => {
   const timezone = userStore.geo?.timezone || 'UTC';
   return dayjs().tz(timezone).startOf('day');
 });
+
+// Live-updating "now" so the displayed time stays current while the page is
+// open. Mirrors the pattern used in EventProgress.vue.
+const now = ref(dayjs());
+let timer: ReturnType<typeof setInterval> | null = null;
+
+// Current local time in the user's timezone, e.g. "9:41 AM GMT+1"
+const currentTime = computed(() => {
+  const timezone = userStore.geo?.timezone || 'UTC';
+  return now.value.tz(timezone).format('h:mm A z');
+});
+
 const todaysEvents = ref([]);
 
 const updateTodaysEvents = () => {
@@ -69,6 +85,14 @@ const shouldShowDate = (event) => {
 
 onMounted(async () => {
   updateTodaysEvents();
+  // Update "now" every minute so the displayed time advances in real time
+  timer = setInterval(() => {
+    now.value = dayjs();
+  }, 60_000);
+});
+
+onUnmounted(() => {
+  if (timer) clearInterval(timer);
 });
 
 watch(
@@ -81,6 +105,12 @@ watch(
 </script>
 
 <style>
+.today__subtitle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5ch;
+}
+
 .events {
   border-top: 1px solid var(--s-color-border);
   padding-top: var(--p-space-s);

--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -3,13 +3,12 @@
     <div class="container flow">
       <hgroup role="group" aria-roledescription="Heading group">
         <h2>Today</h2>
-        <p aria-roledescription="subtitle" class="today__subtitle">
-          <time class="text-muted" :datetime="today.format('YYYY-MM-DD')">{{
-            today.format('MMMM D, YYYY')
-          }}</time>
-          <time class="text-muted" :datetime="now.format('HH:mm')">{{
-            currentTime
-          }}</time>
+        <p aria-roledescription="subtitle">
+          <time
+            class="text-muted"
+            :datetime="localNow.format('YYYY-MM-DDTHH:mmZ')"
+            >{{ localNow.format('MMMM D, YYYY, h:mm A z') }}</time
+          >
         </p>
       </hgroup>
 
@@ -52,15 +51,16 @@ const today = computed(() => {
   return dayjs().tz(timezone).startOf('day');
 });
 
-// Live-updating "now" so the displayed time stays current while the page is
-// open. Mirrors the pattern used in EventProgress.vue.
+// Live-updating "now" so the displayed date and time stay current while the
+// page is open. Mirrors the pattern used in EventProgress.vue.
 const now = ref(dayjs());
 let timer: ReturnType<typeof setInterval> | null = null;
 
-// Current local time in the user's timezone, e.g. "9:41 AM GMT+1"
-const currentTime = computed(() => {
+// "now" in the user's timezone, used for the subtitle date and time,
+// e.g. "June 26, 2026, 9:41 AM GMT+1"
+const localNow = computed(() => {
   const timezone = userStore.geo?.timezone || 'UTC';
-  return now.value.tz(timezone).format('h:mm A z');
+  return now.value.tz(timezone);
 });
 
 const todaysEvents = ref([]);
@@ -104,12 +104,6 @@ watch(
 </script>
 
 <style>
-.today__subtitle {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1ch;
-}
-
 .events {
   border-top: 1px solid var(--s-color-border);
   padding-top: var(--p-space-s);


### PR DESCRIPTION
The Today section showed only the local date. It now shows the current local time alongside it, formatted in the visitor's timezone as "9:41 AM GMT+1", so people can see at a glance what time it is wherever they are.

The time updates itself every minute while the page is open, using the same approach already used for the live event progress bars. When a timezone isn't available it falls back to UTC.