### PR TITLE
Show duration on child event detail page

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -131,6 +131,20 @@ const enumeratedChildTypes = (() => {
   return `${joined} at ${event.title}`;
 })();
 
+// Duration display for child events with both start and end dates.
+const eventDuration = (() => {
+  if (!isChildEvent || !event.dateStart || !event.dateEnd) return null;
+  const minutes = dayjs(event.dateEnd).diff(dayjs(event.dateStart), 'minutes');
+  if (minutes <= 0) return null;
+  if (minutes <= 60)
+    return { iso: `PT${minutes}M`, label: `${minutes} minutes long` };
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const label =
+    mins > 0 ? `${hours} hours ${mins} minutes long` : `${hours} hours long`;
+  return { iso: `PT${minutes}M`, label };
+})();
+
 // Has the event ended? Used to hide supplementary links (registration,
 // schedule, etc.) once they're no longer relevant. Uses the same end-date
 // resolution as progressUtils.hasEnded() but without the showEnded gate,
@@ -338,6 +352,15 @@ const jsonLd = {
             />
           ) : (
             <p class="text-muted">Not yet scheduled</p>
+          )
+        }
+
+        {
+          eventDuration && (
+            <span class="event__duration">
+              <span class="sr-only">Duration</span>
+              <time datetime={eventDuration.iso}>{eventDuration.label}</time>
+            </span>
           )
         }
 
@@ -641,7 +664,9 @@ const jsonLd = {
   .event-detail
     :global(.event__dates:not(.event-detail__children .event__dates)),
   .event-detail
-    :global(.event__delivery:not(.event-detail__children .event__delivery)) {
+    :global(.event__delivery:not(.event-detail__children .event__delivery)),
+  .event-detail
+    :global(.event__duration:not(.event-detail__children .event__duration)) {
     font-size: var(--p-step-0);
   }
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -340,27 +340,39 @@ const jsonLd = {
 
         {
           event.dateStart ? (
-            <EventDate
-              client:only="vue"
-              dateStart={event.dateStart}
-              dateEnd={event.dateEnd}
-              timezone={event.timezone}
-              day={event.day}
-              type={event.type}
-              showCountdown={true}
-              showEnded={true}
-            />
+            eventDuration ? (
+              <div class="event__meta">
+                <EventDate
+                  client:only="vue"
+                  dateStart={event.dateStart}
+                  dateEnd={event.dateEnd}
+                  timezone={event.timezone}
+                  day={event.day}
+                  type={event.type}
+                  showCountdown={true}
+                  showEnded={true}
+                />
+                <span class="event__duration">
+                  <span class="sr-only">Duration</span>
+                  <time datetime={eventDuration.iso}>
+                    {eventDuration.label}
+                  </time>
+                </span>
+              </div>
+            ) : (
+              <EventDate
+                client:only="vue"
+                dateStart={event.dateStart}
+                dateEnd={event.dateEnd}
+                timezone={event.timezone}
+                day={event.day}
+                type={event.type}
+                showCountdown={true}
+                showEnded={true}
+              />
+            )
           ) : (
             <p class="text-muted">Not yet scheduled</p>
-          )
-        }
-
-        {
-          eventDuration && (
-            <span class="event__duration">
-              <span class="sr-only">Duration</span>
-              <time datetime={eventDuration.iso}>{eventDuration.label}</time>
-            </span>
           )
         }
 
@@ -663,10 +675,9 @@ const jsonLd = {
      EventChild components mean we can't use a direct-child combinator. */
   .event-detail
     :global(.event__dates:not(.event-detail__children .event__dates)),
+  .event-detail :global(.event__meta:not(.event-detail__children .event__meta)),
   .event-detail
-    :global(.event__delivery:not(.event-detail__children .event__delivery)),
-  .event-detail
-    :global(.event__duration:not(.event-detail__children .event__duration)) {
+    :global(.event__delivery:not(.event-detail__children .event__delivery)) {
     font-size: var(--p-step-0);
   }
 


### PR DESCRIPTION
Duration was already displayed in event listings (via `EventDuration.vue` inside `EventChild`), but was missing from the child event's own detail page.

## Changes

- Adds `eventDuration` calculation in the `[slug].astro` frontmatter — server-side, no extra Vue island needed
- Renders a `<span class="event__duration">` with a screen-reader label and a `<time datetime>` element after the dates in the detail page header
- Extends the existing `:global()` font-size rule to also scale the duration to `--p-step-0` on the detail page, matching dates and delivery mode

Formatting is identical to `EventDuration.vue`: "X minutes long", "X hours long", or "X hours Y minutes long".