### PR TITLE
feat(dates): omit year from upcoming event dates

### DIFF
--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -244,7 +244,11 @@ const speakerDisplay = computed(() => {
           :aria-label="`Accessibility highlights for ${event.title}`"
         >
           <li v-for="child in event.children" :key="child._id">
-            <EventChild :event="child" :showEnded="showEnded" :isPast="isPast" />
+            <EventChild
+              :event="child"
+              :showEnded="showEnded"
+              :isPast="isPast"
+            />
           </li>
         </ol>
       </details>

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -16,11 +16,13 @@ const props = withDefaults(
     showDate?: boolean;
     showCountdown?: boolean;
     showEnded?: boolean;
+    isPast?: boolean;
   }>(),
   {
     showDate: true,
     showCountdown: false,
     showEnded: false,
+    isPast: false,
   }
 );
 
@@ -176,6 +178,7 @@ const speakerDisplay = computed(() => {
       :dateStart="event.dateStart"
       :timezone="event.timezone"
       :isDeadline="true"
+      :isPast="isPast"
     />
     <span class="event__title"
       >Submit proposals for
@@ -199,6 +202,7 @@ const speakerDisplay = computed(() => {
       :timezone="event.timezone"
       :day="event.day"
       :type="event.type"
+      :isPast="isPast"
       :showCountdown="showCountdown"
       :showEnded="showEnded"
     />
@@ -240,7 +244,7 @@ const speakerDisplay = computed(() => {
           :aria-label="`Accessibility highlights for ${event.title}`"
         >
           <li v-for="child in event.children" :key="child._id">
-            <EventChild :event="child" :showEnded="showEnded" />
+            <EventChild :event="child" :showEnded="showEnded" :isPast="isPast" />
           </li>
         </ol>
       </details>

--- a/src/components/EventChild.vue
+++ b/src/components/EventChild.vue
@@ -16,9 +16,11 @@ const props = withDefaults(
   defineProps<{
     event: ChildEvent;
     showEnded?: boolean;
+    isPast?: boolean;
   }>(),
   {
     showEnded: false,
+    isPast: false,
   }
 );
 
@@ -103,6 +105,7 @@ const speakersList = computed(() => {
           :timezone="event.timezone"
           :day="event.day"
           :type="event.type"
+          :isPast="isPast"
           :showEnded="showEnded"
         />
         <template v-if="event.dateEnd && !inProgress && !ended">

--- a/src/components/EventDate.vue
+++ b/src/components/EventDate.vue
@@ -60,6 +60,7 @@ const props = withDefaults(
     day?: boolean;
     isDeadline?: boolean;
     type?: string;
+    isPast?: boolean;
     showCountdown?: boolean;
     showEnded?: boolean;
   }>(),
@@ -68,6 +69,7 @@ const props = withDefaults(
     day: false,
     isDeadline: false,
     type: 'event',
+    isPast: false,
     showCountdown: false,
     showEnded: false,
   }
@@ -138,6 +140,7 @@ const formattedRange = computed(() =>
     day: props.day,
     type: props.type,
     isDeadline: props.isDeadline,
+    isPast: props.isPast,
   })
 );
 

--- a/src/components/EventList.vue
+++ b/src/components/EventList.vue
@@ -202,7 +202,12 @@ watch(
               :book="event"
               client:visible
             />
-            <Event v-else :event="event" :isPast="type === 'past'" client:visible />
+            <Event
+              v-else
+              :event="event"
+              :isPast="type === 'past'"
+              client:visible
+            />
           </li>
         </ol>
       </section>

--- a/src/components/EventList.vue
+++ b/src/components/EventList.vue
@@ -202,7 +202,7 @@ watch(
               :book="event"
               client:visible
             />
-            <Event v-else :event="event" client:visible />
+            <Event v-else :event="event" :isPast="type === 'past'" client:visible />
           </li>
         </ol>
       </section>

--- a/src/components/StaticEvent.astro
+++ b/src/components/StaticEvent.astro
@@ -13,9 +13,10 @@ import { formatDateRange } from '../utils/dateUtils';
 
 interface Props {
   event: Event;
+  isPast?: boolean;
 }
 
-const { event } = Astro.props;
+const { event, isPast = false } = Astro.props;
 
 const isDeadline = event.type === 'deadline';
 const isTheme = event.type === 'theme';
@@ -43,6 +44,7 @@ const formattedRange = formatDateRange({
   day: isAllDay,
   type: event.type,
   isDeadline,
+  isPast,
   locale: 'en',
 });
 

--- a/src/components/StaticEventList.astro
+++ b/src/components/StaticEventList.astro
@@ -79,7 +79,7 @@ try {
                 {item._type === 'book' ? (
                   <StaticEventBook book={item as Book} />
                 ) : (
-                  <StaticEvent event={item as Event} />
+                  <StaticEvent event={item as Event} isPast={type === 'past'} />
                 )}
               </li>
             ))}

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -131,6 +131,20 @@ const enumeratedChildTypes = (() => {
   return `${joined} at ${event.title}`;
 })();
 
+// Duration display for child events with both start and end dates.
+const eventDuration = (() => {
+  if (!isChildEvent || !event.dateStart || !event.dateEnd) return null;
+  const minutes = dayjs(event.dateEnd).diff(dayjs(event.dateStart), 'minutes');
+  if (minutes <= 0) return null;
+  if (minutes <= 60)
+    return { iso: `PT${minutes}M`, label: `${minutes} minutes long` };
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const label =
+    mins > 0 ? `${hours} hours ${mins} minutes long` : `${hours} hours long`;
+  return { iso: `PT${minutes}M`, label };
+})();
+
 // Has the event ended? Used to hide supplementary links (registration,
 // schedule, etc.) once they're no longer relevant. Uses the same end-date
 // resolution as progressUtils.hasEnded() but without the showEnded gate,
@@ -338,6 +352,15 @@ const jsonLd = {
             />
           ) : (
             <p class="text-muted">Not yet scheduled</p>
+          )
+        }
+
+        {
+          eventDuration && (
+            <span class="event__duration">
+              <span class="sr-only">Duration</span>
+              <time datetime={eventDuration.iso}>{eventDuration.label}</time>
+            </span>
           )
         }
 
@@ -641,7 +664,9 @@ const jsonLd = {
   .event-detail
     :global(.event__dates:not(.event-detail__children .event__dates)),
   .event-detail
-    :global(.event__delivery:not(.event-detail__children .event__delivery)) {
+    :global(.event__delivery:not(.event-detail__children .event__delivery)),
+  .event-detail
+    :global(.event__duration:not(.event-detail__children .event__duration)) {
     font-size: var(--p-step-0);
   }
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -340,27 +340,39 @@ const jsonLd = {
 
         {
           event.dateStart ? (
-            <EventDate
-              client:only="vue"
-              dateStart={event.dateStart}
-              dateEnd={event.dateEnd}
-              timezone={event.timezone}
-              day={event.day}
-              type={event.type}
-              showCountdown={true}
-              showEnded={true}
-            />
+            eventDuration ? (
+              <div class="event__meta">
+                <EventDate
+                  client:only="vue"
+                  dateStart={event.dateStart}
+                  dateEnd={event.dateEnd}
+                  timezone={event.timezone}
+                  day={event.day}
+                  type={event.type}
+                  showCountdown={true}
+                  showEnded={true}
+                />
+                <span class="event__duration">
+                  <span class="sr-only">Duration</span>
+                  <time datetime={eventDuration.iso}>
+                    {eventDuration.label}
+                  </time>
+                </span>
+              </div>
+            ) : (
+              <EventDate
+                client:only="vue"
+                dateStart={event.dateStart}
+                dateEnd={event.dateEnd}
+                timezone={event.timezone}
+                day={event.day}
+                type={event.type}
+                showCountdown={true}
+                showEnded={true}
+              />
+            )
           ) : (
             <p class="text-muted">Not yet scheduled</p>
-          )
-        }
-
-        {
-          eventDuration && (
-            <span class="event__duration">
-              <span class="sr-only">Duration</span>
-              <time datetime={eventDuration.iso}>{eventDuration.label}</time>
-            </span>
           )
         }
 
@@ -663,10 +675,9 @@ const jsonLd = {
      EventChild components mean we can't use a direct-child combinator. */
   .event-detail
     :global(.event__dates:not(.event-detail__children .event__dates)),
+  .event-detail :global(.event__meta:not(.event-detail__children .event__meta)),
   .event-detail
-    :global(.event__delivery:not(.event-detail__children .event__delivery)),
-  .event-detail
-    :global(.event__duration:not(.event-detail__children .event__duration)) {
+    :global(.event__delivery:not(.event-detail__children .event__delivery)) {
     font-size: var(--p-step-0);
   }
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -136,12 +136,17 @@ const eventDuration = (() => {
   if (!isChildEvent || !event.dateStart || !event.dateEnd) return null;
   const minutes = dayjs(event.dateEnd).diff(dayjs(event.dateStart), 'minutes');
   if (minutes <= 0) return null;
-  if (minutes <= 60)
-    return { iso: `PT${minutes}M`, label: `${minutes} minutes long` };
+  if (minutes <= 60) {
+    const minuteLabel = minutes === 1 ? 'minute' : 'minutes';
+    return { iso: `PT${minutes}M`, label: `${minutes} ${minuteLabel} long` };
+  }
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
+  const hourLabel = hours === 1 ? 'hour' : 'hours';
   const label =
-    mins > 0 ? `${hours} hours ${mins} minutes long` : `${hours} hours long`;
+    mins > 0
+      ? `${hours} ${hourLabel} ${mins} ${mins === 1 ? 'minute' : 'minutes'} long`
+      : `${hours} ${hourLabel} long`;
   return { iso: `PT${minutes}M`, label };
 })();
 
@@ -349,6 +354,7 @@ const jsonLd = {
                   timezone={event.timezone}
                   day={event.day}
                   type={event.type}
+                  isPast={eventHasEnded}
                   showCountdown={true}
                   showEnded={true}
                 />
@@ -367,6 +373,7 @@ const jsonLd = {
                 timezone={event.timezone}
                 day={event.day}
                 type={event.type}
+                isPast={eventHasEnded}
                 showCountdown={true}
                 showEnded={true}
               />

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -916,10 +916,7 @@ describe('formatDateRange', () => {
         type: 'theme',
       });
       // Oct 1–30 is not the full month (31 days), should show normal range; no year for upcoming
-      expect(result).toEqual([
-        'Thursday, October 1',
-        'Friday, October 30',
-      ]);
+      expect(result).toEqual(['Thursday, October 1', 'Friday, October 30']);
     });
 
     it('does not apply to ranges starting after the 1st', () => {
@@ -931,10 +928,7 @@ describe('formatDateRange', () => {
         type: 'theme',
       });
       // No year for upcoming
-      expect(result).toEqual([
-        'Friday, October 2',
-        'Saturday, October 31',
-      ]);
+      expect(result).toEqual(['Friday, October 2', 'Saturday, October 31']);
     });
 
     it('does not apply to cross-month ranges', () => {
@@ -946,10 +940,7 @@ describe('formatDateRange', () => {
         type: 'theme',
       });
       // Oct 1 – Nov 30 spans two months; no year for upcoming
-      expect(result).toEqual([
-        'Thursday, October 1',
-        'Monday, November 30',
-      ]);
+      expect(result).toEqual(['Thursday, October 1', 'Monday, November 30']);
     });
 
     it('does not apply to timed events (not date-only)', () => {

--- a/src/utils/dateUtils.test.ts
+++ b/src/utils/dateUtils.test.ts
@@ -376,31 +376,63 @@ describe('getYearMonth', () => {
 
 describe('formatDateRange', () => {
   describe('single date (no end date)', () => {
-    it('returns a single-element tuple for timed events', () => {
+    it('returns a single-element tuple for timed events (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T14:00:00Z',
         timezone: 'UTC',
         locale: 'en',
       });
+      expect(result).toEqual([`Sunday, March 8 2:00${nbsp}PM`]);
+    });
+
+    it('returns a single-element tuple for timed events (past — shows year)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T14:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        isPast: true,
+      });
       expect(result).toEqual([`Sunday, March 8, 2026 2:00${nbsp}PM`]);
     });
 
-    it('returns a single-element tuple for all-day events', () => {
+    it('returns a single-element tuple for all-day events (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',
         timezone: 'UTC',
         locale: 'en',
         day: true,
       });
+      expect(result).toEqual(['Sunday, March 8']);
+    });
+
+    it('returns a single-element tuple for all-day events (past — shows year)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        day: true,
+        isPast: true,
+      });
       expect(result).toEqual(['Sunday, March 8, 2026']);
     });
 
-    it('returns a single-element tuple for themes', () => {
+    it('returns a single-element tuple for themes (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',
         timezone: 'UTC',
         locale: 'en',
         type: 'theme',
+      });
+      expect(result).toEqual(['Sunday, March 8']);
+    });
+
+    it('returns a single-element tuple for themes (past — shows year)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        type: 'theme',
+        isPast: true,
       });
       expect(result).toEqual(['Sunday, March 8, 2026']);
     });
@@ -414,8 +446,8 @@ describe('formatDateRange', () => {
         timezone: 'UTC',
         locale: 'en',
       });
-      // Both PM — AM/PM shown only on end time
-      expect(result).toEqual(['Sunday, March 8, 2026 2:00', `5:00${nbsp}PM`]);
+      // Both PM — AM/PM shown only on end time; no year for upcoming
+      expect(result).toEqual(['Sunday, March 8 2:00', `5:00${nbsp}PM`]);
     });
 
     it('shows AM/PM on both times when they differ', () => {
@@ -425,9 +457,9 @@ describe('formatDateRange', () => {
         timezone: 'UTC',
         locale: 'en',
       });
-      // AM → PM — both shown
+      // AM → PM — both shown; no year for upcoming
       expect(result).toEqual([
-        `Sunday, March 8, 2026 10:00${nbsp}AM`,
+        `Sunday, March 8 10:00${nbsp}AM`,
         `5:00${nbsp}PM`,
       ]);
     });
@@ -439,8 +471,8 @@ describe('formatDateRange', () => {
         timezone: 'UTC',
         locale: 'en',
       });
-      // Both AM — AM/PM shown only on end time
-      expect(result).toEqual(['Sunday, March 8, 2026 8:00', `11:00${nbsp}AM`]);
+      // Both AM — AM/PM shown only on end time; no year for upcoming
+      expect(result).toEqual(['Sunday, March 8 8:00', `11:00${nbsp}AM`]);
     });
 
     it('skips AM/PM dedup for 24-hour locales', () => {
@@ -450,8 +482,8 @@ describe('formatDateRange', () => {
         timezone: 'UTC',
         locale: 'de',
       });
-      // 24-hour locale — no AM/PM to deduplicate
-      expect(result).toEqual(['Sonntag, 8. März 2026 14:00', '17:00']);
+      // 24-hour locale — no AM/PM to deduplicate; no year for upcoming
+      expect(result).toEqual(['Sonntag, 8. März 14:00', '17:00']);
     });
 
     it('returns single-element tuple for same-day date-only events', () => {
@@ -462,12 +494,24 @@ describe('formatDateRange', () => {
         locale: 'en',
         day: true,
       });
-      expect(result).toEqual(['Sunday, March 8, 2026']);
+      // No year for upcoming
+      expect(result).toEqual(['Sunday, March 8']);
+    });
+
+    it('shows year on same-day events when isPast is true', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T14:00:00Z',
+        dateEnd: '2026-03-08T17:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        isPast: true,
+      });
+      expect(result).toEqual(['Sunday, March 8, 2026 2:00', `5:00${nbsp}PM`]);
     });
   });
 
   describe('same-month date ranges (the key optimization)', () => {
-    it('deduplicates month and year for date-only ranges (en)', () => {
+    it('deduplicates month for date-only ranges (upcoming — no year on either end)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',
         dateEnd: '2026-03-13T00:00:00Z',
@@ -475,18 +519,42 @@ describe('formatDateRange', () => {
         locale: 'en',
         day: true,
       });
+      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13']);
+    });
+
+    it('deduplicates month and year for date-only ranges (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T00:00:00Z',
+        dateEnd: '2026-03-13T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        day: true,
+        isPast: true,
+      });
       expect(result).toEqual(['Sunday, March 8', 'Friday, March 13, 2026']);
     });
   });
 
   describe('different-month, same-year ranges', () => {
-    it('deduplicates the year for date-only ranges (en)', () => {
+    it('deduplicates the year for date-only ranges (upcoming — no year on either end)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-28T00:00:00Z',
         dateEnd: '2026-04-02T00:00:00Z',
         timezone: 'UTC',
         locale: 'en',
         day: true,
+      });
+      expect(result).toEqual(['Saturday, March 28', 'Thursday, April 2']);
+    });
+
+    it('deduplicates the year for date-only ranges (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-28T00:00:00Z',
+        dateEnd: '2026-04-02T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        day: true,
+        isPast: true,
       });
       expect(result).toEqual(['Saturday, March 28', 'Thursday, April 2, 2026']);
     });
@@ -509,26 +577,55 @@ describe('formatDateRange', () => {
   });
 
   describe('multi-day timed events', () => {
-    it('deduplicates year for same-year timed ranges', () => {
+    it('deduplicates year for same-year timed ranges (upcoming — no year on end)', () => {
       const result = formatDateRange({
         dateStart: '2026-02-24T14:00:00Z',
         dateEnd: '2026-02-25T21:00:00Z',
         timezone: 'UTC',
         locale: 'en',
       });
-      // Start omits year, end keeps it (both have day names)
+      // Start omits year (already year-free format), end also omits year for upcoming
+      expect(result).toEqual([
+        `Tuesday, February 24 2:00${nbsp}PM`,
+        `Wednesday, February 25 9:00${nbsp}PM`,
+      ]);
+    });
+
+    it('deduplicates year for same-year timed ranges (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-02-24T14:00:00Z',
+        dateEnd: '2026-02-25T21:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        isPast: true,
+      });
+      // Start omits year (deduplication), end keeps it
       expect(result).toEqual([
         `Tuesday, February 24 2:00${nbsp}PM`,
         `Wednesday, February 25, 2026 9:00${nbsp}PM`,
       ]);
     });
 
-    it('deduplicates year across different months', () => {
+    it('deduplicates year across different months (upcoming — no year on end)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T14:00:00Z',
         dateEnd: '2026-04-10T17:00:00Z',
         timezone: 'UTC',
         locale: 'en',
+      });
+      expect(result).toEqual([
+        `Sunday, March 8 2:00${nbsp}PM`,
+        `Friday, April 10 5:00${nbsp}PM`,
+      ]);
+    });
+
+    it('deduplicates year across different months (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T14:00:00Z',
+        dateEnd: '2026-04-10T17:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        isPast: true,
       });
       expect(result).toEqual([
         `Sunday, March 8 2:00${nbsp}PM`,
@@ -563,8 +660,8 @@ describe('formatDateRange', () => {
         day: true,
         now: notToday,
       });
-      // In EDT (UTC-4 in March), these are Mar 8 (Sun) and Mar 9 (Mon)
-      expect(result).toEqual(['Sunday, March 8', 'Monday, March 9, 2026']);
+      // In EDT (UTC-4 in March), these are Mar 8 (Sun) and Mar 9 (Mon); no year for upcoming
+      expect(result).toEqual(['Sunday, March 8', 'Monday, March 9']);
     });
 
     it('uses user timezone when useLocalTimezone is true', () => {
@@ -576,8 +673,8 @@ describe('formatDateRange', () => {
         userTimezone: 'Europe/London',
         locale: 'en',
       });
-      // In London (GMT), these are 14:00–17:00 on Mar 8 (both PM)
-      expect(result).toEqual(['Sunday, March 8, 2026 2:00', `5:00${nbsp}PM`]);
+      // In London (GMT), these are 14:00–17:00 on Mar 8 (both PM); no year for upcoming
+      expect(result).toEqual(['Sunday, March 8 2:00', `5:00${nbsp}PM`]);
     });
 
     it('uses UTC for international events (no timezone)', () => {
@@ -586,13 +683,13 @@ describe('formatDateRange', () => {
         dateEnd: '2026-03-08T17:00:00Z',
         locale: 'en',
       });
-      // No timezone = international, should use UTC values (both PM)
-      expect(result).toEqual(['Sunday, March 8, 2026 2:00', `5:00${nbsp}PM`]);
+      // No timezone = international, should use UTC values (both PM); no year for upcoming
+      expect(result).toEqual(['Sunday, March 8 2:00', `5:00${nbsp}PM`]);
     });
   });
 
   describe('locale support', () => {
-    it('formats same-month range in German', () => {
+    it('formats same-month range in German (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',
         dateEnd: '2026-03-13T00:00:00Z',
@@ -600,17 +697,43 @@ describe('formatDateRange', () => {
         locale: 'de',
         day: true,
       });
+      // "Sonntag, 8." / "Freitag, 13." — no year for upcoming
+      expect(result).toEqual(['Sonntag, 8.', 'Freitag, 13.']);
+    });
+
+    it('formats same-month range in German (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T00:00:00Z',
+        dateEnd: '2026-03-13T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'de',
+        day: true,
+        isPast: true,
+      });
       // "Sonntag, 8." / "Freitag, 13. März 2026"
       expect(result).toEqual(['Sonntag, 8.', 'Freitag, 13. März 2026']);
     });
 
-    it('formats different-month range in German', () => {
+    it('formats different-month range in German (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-28T00:00:00Z',
         dateEnd: '2026-04-02T00:00:00Z',
         timezone: 'UTC',
         locale: 'de',
         day: true,
+      });
+      // "Samstag, 28. März" / "Donnerstag, 2. April" — no year for upcoming
+      expect(result).toEqual(['Samstag, 28. März', 'Donnerstag, 2. April']);
+    });
+
+    it('formats different-month range in German (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-28T00:00:00Z',
+        dateEnd: '2026-04-02T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'de',
+        day: true,
+        isPast: true,
       });
       // "Samstag, 28. März" / "Donnerstag, 2. April 2026"
       expect(result).toEqual([
@@ -619,19 +742,32 @@ describe('formatDateRange', () => {
       ]);
     });
 
-    it('formats same-month range in French', () => {
+    it('formats same-month range in French (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',
         dateEnd: '2026-03-13T00:00:00Z',
         timezone: 'UTC',
         locale: 'fr',
         day: true,
+      });
+      // "dimanche 8" / "vendredi 13" — no year for upcoming
+      expect(result).toEqual(['dimanche 8', 'vendredi 13']);
+    });
+
+    it('formats same-month range in French (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T00:00:00Z',
+        dateEnd: '2026-03-13T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'fr',
+        day: true,
+        isPast: true,
       });
       // "dimanche 8" / "vendredi 13 mars 2026"
       expect(result).toEqual(['dimanche 8', 'vendredi 13 mars 2026']);
     });
 
-    it('formats different-month range in French', () => {
+    it('formats different-month range in French (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-28T00:00:00Z',
         dateEnd: '2026-04-02T00:00:00Z',
@@ -639,11 +775,24 @@ describe('formatDateRange', () => {
         locale: 'fr',
         day: true,
       });
+      // "samedi 28 mars" / "jeudi 2 avril" — no year for upcoming
+      expect(result).toEqual(['samedi 28 mars', 'jeudi 2 avril']);
+    });
+
+    it('formats different-month range in French (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-28T00:00:00Z',
+        dateEnd: '2026-04-02T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'fr',
+        day: true,
+        isPast: true,
+      });
       // "samedi 28 mars" / "jeudi 2 avril 2026"
       expect(result).toEqual(['samedi 28 mars', 'jeudi 2 avril 2026']);
     });
 
-    it('formats same-month range in Spanish', () => {
+    it('formats same-month range in Spanish (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-08T00:00:00Z',
         dateEnd: '2026-03-13T00:00:00Z',
@@ -651,17 +800,43 @@ describe('formatDateRange', () => {
         locale: 'es',
         day: true,
       });
+      // "domingo, 8" / "viernes, 13" — no year for upcoming
+      expect(result).toEqual(['domingo, 8', 'viernes, 13']);
+    });
+
+    it('formats same-month range in Spanish (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-08T00:00:00Z',
+        dateEnd: '2026-03-13T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'es',
+        day: true,
+        isPast: true,
+      });
       // "domingo, 8" / "viernes, 13 de marzo de 2026"
       expect(result).toEqual(['domingo, 8', 'viernes, 13 de marzo de 2026']);
     });
 
-    it('formats different-month range in Spanish', () => {
+    it('formats different-month range in Spanish (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-03-28T00:00:00Z',
         dateEnd: '2026-04-02T00:00:00Z',
         timezone: 'UTC',
         locale: 'es',
         day: true,
+      });
+      // "sábado, 28 de marzo" / "jueves, 2 de abril" — no year for upcoming
+      expect(result).toEqual(['sábado, 28 de marzo', 'jueves, 2 de abril']);
+    });
+
+    it('formats different-month range in Spanish (past — year on end)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-03-28T00:00:00Z',
+        dateEnd: '2026-04-02T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'es',
+        day: true,
+        isPast: true,
       });
       // "sábado, 28 de marzo" / "jueves, 2 de abril de 2026"
       expect(result).toEqual([
@@ -672,7 +847,7 @@ describe('formatDateRange', () => {
   });
 
   describe('full-month events', () => {
-    it('displays "October 2026" for a full October (en)', () => {
+    it('displays "October" for a full October upcoming event (en)', () => {
       const result = formatDateRange({
         dateStart: '2026-10-01T00:00:00Z',
         dateEnd: '2026-10-31T00:00:00Z',
@@ -680,10 +855,22 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
+      expect(result).toEqual(['October']);
+    });
+
+    it('displays "October 2026" for a full October past event (en)', () => {
+      const result = formatDateRange({
+        dateStart: '2026-10-01T00:00:00Z',
+        dateEnd: '2026-10-31T00:00:00Z',
+        timezone: 'UTC',
+        locale: 'en',
+        type: 'theme',
+        isPast: true,
+      });
       expect(result).toEqual(['October 2026']);
     });
 
-    it('displays "February 2026" for a full February (en)', () => {
+    it('displays "February" for a full February upcoming event (en)', () => {
       // February 2026 has 28 days
       const result = formatDateRange({
         dateStart: '2026-02-01T00:00:00Z',
@@ -692,10 +879,10 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
-      expect(result).toEqual(['February 2026']);
+      expect(result).toEqual(['February']);
     });
 
-    it('displays "February 2028" for a full leap-year February (en)', () => {
+    it('displays "February 2028" for a full leap-year February past event (en)', () => {
       // February 2028 has 29 days (leap year)
       const result = formatDateRange({
         dateStart: '2028-02-01T00:00:00Z',
@@ -703,6 +890,7 @@ describe('formatDateRange', () => {
         timezone: 'UTC',
         locale: 'en',
         type: 'theme',
+        isPast: true,
       });
       expect(result).toEqual(['February 2028']);
     });
@@ -715,7 +903,8 @@ describe('formatDateRange', () => {
         locale: 'en',
         day: true,
       });
-      expect(result).toEqual(['June 2026']);
+      // No year for upcoming
+      expect(result).toEqual(['June']);
     });
 
     it('does not apply to partial-month ranges', () => {
@@ -726,10 +915,10 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
-      // Oct 1–30 is not the full month (31 days), should show normal range
+      // Oct 1–30 is not the full month (31 days), should show normal range; no year for upcoming
       expect(result).toEqual([
         'Thursday, October 1',
-        'Friday, October 30, 2026',
+        'Friday, October 30',
       ]);
     });
 
@@ -741,9 +930,10 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
+      // No year for upcoming
       expect(result).toEqual([
         'Friday, October 2',
-        'Saturday, October 31, 2026',
+        'Saturday, October 31',
       ]);
     });
 
@@ -755,10 +945,10 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
-      // Oct 1 – Nov 30 spans two months
+      // Oct 1 – Nov 30 spans two months; no year for upcoming
       expect(result).toEqual([
         'Thursday, October 1',
-        'Monday, November 30, 2026',
+        'Monday, November 30',
       ]);
     });
 
@@ -770,14 +960,14 @@ describe('formatDateRange', () => {
         timezone: 'UTC',
         locale: 'en',
       });
-      // Should show as a timed range, not "October 2026"
+      // Should show as a timed range, not "October"; no year for upcoming
       expect(result).toEqual([
         `Thursday, October 1 9:00${nbsp}AM`,
-        `Saturday, October 31, 2026 5:00${nbsp}PM`,
+        `Saturday, October 31 5:00${nbsp}PM`,
       ]);
     });
 
-    it('formats full month in German', () => {
+    it('formats full month in German (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-10-01T00:00:00Z',
         dateEnd: '2026-10-31T00:00:00Z',
@@ -785,10 +975,10 @@ describe('formatDateRange', () => {
         locale: 'de',
         type: 'theme',
       });
-      expect(result).toEqual(['Oktober 2026']);
+      expect(result).toEqual(['Oktober']);
     });
 
-    it('formats full month in French', () => {
+    it('formats full month in French (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-10-01T00:00:00Z',
         dateEnd: '2026-10-31T00:00:00Z',
@@ -796,10 +986,10 @@ describe('formatDateRange', () => {
         locale: 'fr',
         type: 'theme',
       });
-      expect(result).toEqual(['octobre 2026']);
+      expect(result).toEqual(['octobre']);
     });
 
-    it('formats full month in Spanish', () => {
+    it('formats full month in Spanish (upcoming — no year)', () => {
       const result = formatDateRange({
         dateStart: '2026-10-01T00:00:00Z',
         dateEnd: '2026-10-31T00:00:00Z',
@@ -807,7 +997,7 @@ describe('formatDateRange', () => {
         locale: 'es',
         type: 'theme',
       });
-      expect(result).toEqual(['octubre de 2026']);
+      expect(result).toEqual(['octubre']);
     });
 
     it('works for international events (no timezone)', () => {
@@ -817,7 +1007,8 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
-      expect(result).toEqual(['October 2026']);
+      // No year for upcoming
+      expect(result).toEqual(['October']);
     });
   });
 
@@ -830,8 +1021,8 @@ describe('formatDateRange', () => {
         locale: 'en',
         type: 'theme',
       });
-      // Should be date-only with day names
-      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13, 2026']);
+      // Should be date-only with day names; no year for upcoming
+      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13']);
     });
 
     it('omits time for deadlines', () => {
@@ -842,7 +1033,8 @@ describe('formatDateRange', () => {
         locale: 'en',
         isDeadline: true,
       });
-      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13, 2026']);
+      // No year for upcoming
+      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13']);
     });
 
     it('omits time for all-day events', () => {
@@ -853,7 +1045,8 @@ describe('formatDateRange', () => {
         locale: 'en',
         day: true,
       });
-      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13, 2026']);
+      // No year for upcoming
+      expect(result).toEqual(['Sunday, March 8', 'Friday, March 13']);
     });
   });
 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -297,6 +297,43 @@ const FULL_MONTH_FORMATS: Record<string, string> = {
 };
 
 /**
+ * Year-free date-only format strings per locale.
+ *
+ * Used for upcoming events where the year is implicit and can be omitted
+ * to reduce visual noise. Matches the day/month portion of the LL locale
+ * format without the year component.
+ *
+ * English:  "March 8"
+ * German:   "8. März"
+ * French:   "8 mars"
+ * Spanish:  "8 de marzo"
+ */
+const NO_YEAR_DATE_ONLY: Record<string, string> = {
+  en: 'MMMM D',
+  de: 'D. MMMM',
+  fr: 'D MMMM',
+  es: 'D [de] MMMM',
+};
+
+/**
+ * Year-free timed format strings per locale (LLLL equivalent without year).
+ *
+ * Used for upcoming timed events. Includes the day name and time but omits
+ * the year.
+ *
+ * English:  "Sunday, March 8 2:00 PM"
+ * German:   "Sonntag, 8. März 14:00"
+ * French:   "dimanche 8 mars 14:00"
+ * Spanish:  "domingo, 8 de marzo 2:00 PM"
+ */
+const NO_YEAR_TIMED: Record<string, string> = {
+  en: 'dddd, MMMM D LT',
+  de: 'dddd, D. MMMM LT',
+  fr: 'dddd D MMMM LT',
+  es: 'dddd, D [de] MMMM LT',
+};
+
+/**
  * Checks if a date range spans an entire calendar month.
  *
  * Returns true when the start date is the 1st and the end date is
@@ -353,6 +390,11 @@ export function formatDateRange(options: {
   day?: boolean;
   type?: string;
   isDeadline?: boolean;
+  /**
+   * Whether the event is in the past. When false (upcoming), the year is
+   * omitted from display to reduce visual noise. Defaults to false.
+   */
+  isPast?: boolean;
   /** Injected "now" for testability; defaults to the real current time. */
   now?: dayjs.Dayjs;
 }): DateRangeParts {
@@ -417,9 +459,30 @@ export function formatDateRange(options: {
     return formatted;
   }
 
+  // Whether the year should be shown. For upcoming events (isPast = false/undefined),
+  // the year is omitted to reduce visual noise. Year is always shown for past events
+  // and for ranges that span a year boundary (which need the year for clarity).
+  const showYear = !!options.isPast;
+
+  // Year-free date-only format for the current locale
+  const noYearDateOnly = NO_YEAR_DATE_ONLY[locale] || NO_YEAR_DATE_ONLY.en;
+  // Year-free timed format for the current locale (LLLL equivalent without year)
+  const noYearTimed = NO_YEAR_TIMED[locale] || NO_YEAR_TIMED.en;
+
+  const dp = dayPrefix(locale);
+
   // No end date — return a single formatted date
   if (!options.dateEnd) {
-    const format = getStartDateFormat(options);
+    let format: string;
+    const isDateOnlySingle =
+      options.type === 'theme' || options.isDeadline || options.day;
+    if (showYear) {
+      format = getStartDateFormat(options);
+    } else if (isDateOnlySingle) {
+      format = `${dp}${noYearDateOnly}`;
+    } else {
+      format = noYearTimed;
+    }
     const startDj = isInternational
       ? dayjs.utc(options.dateStart).locale(locale)
       : dayjs.utc(options.dateStart).tz(tz).locale(locale);
@@ -443,21 +506,23 @@ export function formatDateRange(options: {
     ? dayjs.utc(options.dateEnd).locale(locale)
     : dayjs.utc(options.dateEnd).tz(tz).locale(locale);
 
-  const dp = dayPrefix(locale);
+  // For year-spanning ranges, always show the year regardless of isPast
+  const sameYear = start.isSame(end, 'year');
+  const dateFmt = showYear || !sameYear ? `${dp}LL` : `${dp}${noYearDateOnly}`;
 
   // Same day — timed events show "date time" / "time", date-only returns single date
   if (start.isSame(end, 'day')) {
     if (isDateOnly) {
       return [
-        relativeDay(start, nonBreakingTime(start.format(`${dp}LL`)), `${dp}LL`),
+        relativeDay(start, nonBreakingTime(start.format(dateFmt)), dateFmt),
       ];
     }
     const startTime = deduplicateAmPm(start, end, locale);
     return [
       relativeDay(
         start,
-        nonBreakingTime(`${start.format(`${dp}LL`)} ${startTime}`),
-        `${dp}LL`
+        nonBreakingTime(`${start.format(dateFmt)} ${startTime}`),
+        dateFmt
       ),
       nonBreakingTime(end.format('LT')),
     ];
@@ -467,7 +532,9 @@ export function formatDateRange(options: {
 
   // Timed multi-day events: deduplicate year when same year
   if (!isDateOnly) {
-    if (start.isSame(end, 'year')) {
+    if (sameYear) {
+      // End format: LLLL (with year) for past, year-free timed for upcoming
+      const timedEndFmt = showYear ? formats.timedSameYear.end : noYearTimed;
       return [
         relativeDay(
           start,
@@ -476,8 +543,8 @@ export function formatDateRange(options: {
         ),
         relativeDay(
           end,
-          nonBreakingTime(end.format(formats.timedSameYear.end)),
-          formats.timedSameYear.end
+          nonBreakingTime(end.format(timedEndFmt)),
+          timedEndFmt
         ),
       ];
     }
@@ -495,24 +562,28 @@ export function formatDateRange(options: {
     ];
   }
 
-  // Full-month events: display as "October 2026" instead of a verbose range
+  // Full-month events: display as "October 2026" for past, "October" for upcoming
   if (isFullMonth(start, end)) {
-    const fullMonthFmt = FULL_MONTH_FORMATS[locale] || FULL_MONTH_FORMATS.en;
+    const fullMonthFmt = showYear
+      ? FULL_MONTH_FORMATS[locale] || FULL_MONTH_FORMATS.en
+      : 'MMMM';
     return [start.format(fullMonthFmt)];
   }
 
   // Date-only multi-day ranges: deduplicate shared components
-  if (start.isSame(end, 'year')) {
+  if (sameYear) {
     const fmt = start.isSame(end, 'month')
       ? formats.sameMonth
       : formats.diffMonth;
+    // For upcoming events, omit the year from the end date too
+    const endFmt = showYear ? fmt.end : fmt.start;
     return [
       relativeDay(start, nonBreakingTime(start.format(fmt.start)), fmt.start),
-      relativeDay(end, nonBreakingTime(end.format(fmt.end)), fmt.end),
+      relativeDay(end, nonBreakingTime(end.format(endFmt)), endFmt),
     ];
   }
 
-  // Different years: no deduplication possible
+  // Different years: always show year for clarity
   return [
     relativeDay(
       start,

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -541,11 +541,7 @@ export function formatDateRange(options: {
           nonBreakingTime(start.format(formats.timedSameYear.start)),
           formats.timedSameYear.start
         ),
-        relativeDay(
-          end,
-          nonBreakingTime(end.format(timedEndFmt)),
-          timedEndFmt
-        ),
+        relativeDay(end, nonBreakingTime(end.format(timedEndFmt)), timedEndFmt),
       ];
     }
     return [


### PR DESCRIPTION
## Summary

Year is implicit for upcoming events and adds visual noise. Past events retain the year for historical context. Cross-year ranges always show the year regardless of context.

This PR also ships the duration display on child event detail pages (from earlier commits on this branch).

## Changes

### `src/utils/dateUtils.ts`
- Added `NO_YEAR_DATE_ONLY` and `NO_YEAR_TIMED` locale-specific format constants (en, de, fr, es)
- Added `isPast?: boolean` option to `formatDateRange` (defaults to `false`)
- When `isPast` is falsy, year is omitted from same-year date formats
- Cross-year ranges always retain year for clarity

### Component chain (year omission)
- `EventList.vue` → passes `:isPast="type === 'past'"` to `Event`
- `Event.vue` → accepts and forwards `isPast` to `EventDate` and `EventChild`
- `EventChild.vue` → accepts and forwards `isPast` to `EventDate`
- `EventDate.vue` → passes `isPast` to `formatDateRange`
- `StaticEventList.astro` / `StaticEvent.astro` — same for SSR fallback
- `events/[slug].astro` — both `EventDate` instances pass `isPast={eventHasEnded}`

### Duration display (`events/[slug].astro`)
- Shows duration (e.g. "2 hours 30 minutes long") inline with the date on child event detail pages
- Singular/plural handled correctly ("1 minute", "1 hour")

### Tests
- Updated existing tests to reflect year-free upcoming defaults
- Added `isPast: true` counterpart tests documenting past-event (year-shown) behaviour