### PR TITLE
feat(events): show duration on child event detail pages

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -136,12 +136,17 @@ const eventDuration = (() => {
   if (!isChildEvent || !event.dateStart || !event.dateEnd) return null;
   const minutes = dayjs(event.dateEnd).diff(dayjs(event.dateStart), 'minutes');
   if (minutes <= 0) return null;
-  if (minutes <= 60)
-    return { iso: `PT${minutes}M`, label: `${minutes} minutes long` };
+  if (minutes <= 60) {
+    const minuteLabel = minutes === 1 ? 'minute' : 'minutes';
+    return { iso: `PT${minutes}M`, label: `${minutes} ${minuteLabel} long` };
+  }
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
+  const hourLabel = hours === 1 ? 'hour' : 'hours';
   const label =
-    mins > 0 ? `${hours} hours ${mins} minutes long` : `${hours} hours long`;
+    mins > 0
+      ? `${hours} ${hourLabel} ${mins} ${mins === 1 ? 'minute' : 'minutes'} long`
+      : `${hours} ${hourLabel} long`;
   return { iso: `PT${minutes}M`, label };
 })();
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -355,7 +355,7 @@ const jsonLd = {
                   day={event.day}
                   type={event.type}
                   isPast={eventHasEnded}
-                  showCountdown={true}
+                  showCountdown={false}
                   showEnded={true}
                 />
                 <span class="event__duration">

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -131,6 +131,20 @@ const enumeratedChildTypes = (() => {
   return `${joined} at ${event.title}`;
 })();
 
+// Duration display for child events with both start and end dates.
+const eventDuration = (() => {
+  if (!isChildEvent || !event.dateStart || !event.dateEnd) return null;
+  const minutes = dayjs(event.dateEnd).diff(dayjs(event.dateStart), 'minutes');
+  if (minutes <= 0) return null;
+  if (minutes <= 60)
+    return { iso: `PT${minutes}M`, label: `${minutes} minutes long` };
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  const label =
+    mins > 0 ? `${hours} hours ${mins} minutes long` : `${hours} hours long`;
+  return { iso: `PT${minutes}M`, label };
+})();
+
 // Has the event ended? Used to hide supplementary links (registration,
 // schedule, etc.) once they're no longer relevant. Uses the same end-date
 // resolution as progressUtils.hasEnded() but without the showEnded gate,
@@ -339,6 +353,15 @@ const jsonLd = {
             />
           ) : (
             <p class="text-muted">Not yet scheduled</p>
+          )
+        }
+
+        {
+          eventDuration && (
+            <span class="event__duration">
+              <span class="sr-only">Duration</span>
+              <time datetime={eventDuration.iso}>{eventDuration.label}</time>
+            </span>
           )
         }
 
@@ -642,7 +665,9 @@ const jsonLd = {
   .event-detail
     :global(.event__dates:not(.event-detail__children .event__dates)),
   .event-detail
-    :global(.event__delivery:not(.event-detail__children .event__delivery)) {
+    :global(.event__delivery:not(.event-detail__children .event__delivery)),
+  .event-detail
+    :global(.event__duration:not(.event-detail__children .event__duration)) {
     font-size: var(--p-step-0);
   }
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -340,28 +340,41 @@ const jsonLd = {
 
         {
           event.dateStart ? (
-            <EventDate
-              client:only="vue"
-              dateStart={event.dateStart}
-              dateEnd={event.dateEnd}
-              timezone={event.timezone}
-              day={event.day}
-              type={event.type}
-              isPast={eventHasEnded}
-              showCountdown={true}
-              showEnded={true}
-            />
+            eventDuration ? (
+              <div class="event__meta">
+                <EventDate
+                  client:only="vue"
+                  dateStart={event.dateStart}
+                  dateEnd={event.dateEnd}
+                  timezone={event.timezone}
+                  day={event.day}
+                  type={event.type}
+                  isPast={eventHasEnded}
+                  showCountdown={true}
+                  showEnded={true}
+                />
+                <span class="event__duration">
+                  <span class="sr-only">Duration</span>
+                  <time datetime={eventDuration.iso}>
+                    {eventDuration.label}
+                  </time>
+                </span>
+              </div>
+            ) : (
+              <EventDate
+                client:only="vue"
+                dateStart={event.dateStart}
+                dateEnd={event.dateEnd}
+                timezone={event.timezone}
+                day={event.day}
+                type={event.type}
+                isPast={eventHasEnded}
+                showCountdown={true}
+                showEnded={true}
+              />
+            )
           ) : (
             <p class="text-muted">Not yet scheduled</p>
-          )
-        }
-
-        {
-          eventDuration && (
-            <span class="event__duration">
-              <span class="sr-only">Duration</span>
-              <time datetime={eventDuration.iso}>{eventDuration.label}</time>
-            </span>
           )
         }
 
@@ -664,10 +677,9 @@ const jsonLd = {
      EventChild components mean we can't use a direct-child combinator. */
   .event-detail
     :global(.event__dates:not(.event-detail__children .event__dates)),
+  .event-detail :global(.event__meta:not(.event-detail__children .event__meta)),
   .event-detail
-    :global(.event__delivery:not(.event-detail__children .event__delivery)),
-  .event-detail
-    :global(.event__duration:not(.event-detail__children .event__duration)) {
+    :global(.event__delivery:not(.event-detail__children .event__delivery)) {
     font-size: var(--p-step-0);
   }
 

--- a/src/styles/_events.css
+++ b/src/styles/_events.css
@@ -128,6 +128,17 @@
   flex: 1 1 100%;
 }
 
+/* When a countdown/progress element forces the dates block to span the full
+   row, the duration drops onto its own line. Suppress the leading separator
+   so it reads cleanly ("3 hours long") instead of as a dangling "· 3 hours
+   long" bullet. Matches the direct child of .event__meta that contains the
+   progress element so it works whether or not EventDate is wrapped in an
+   Astro island (client:only) on the detail page. */
+.event__meta > *:has(.event__progress) ~ .event__duration::before {
+  content: none;
+  margin-right: 0;
+}
+
 .event > .event__description {
   order: 4;
 }


### PR DESCRIPTION
## Summary

Child event detail pages (e.g. individual conference talks) now display the session duration inline with the date when both a start and end time are present.

## Changes

- `events/[slug].astro`: computes duration from `dateStart`/`dateEnd` and renders it as a `<time>` element with an ISO 8601 `datetime` attribute
- Correct singular/plural for hours and minutes ("1 hour", "2 hours", "1 minute", "30 minutes")