### PR TITLE
feat: omit year from Today section date display

### DIFF
--- a/src/components/Today.vue
+++ b/src/components/Today.vue
@@ -7,7 +7,7 @@
           <time
             class="text-muted"
             :datetime="localNow.format('YYYY-MM-DDTHH:mmZ')"
-            >{{ localNow.format('MMMM D, YYYY, h:mm A z') }}</time
+            >{{ localNow.format('MMMM D, h:mm A z') }}</time
           >
         </p>
       </hgroup>


### PR DESCRIPTION
The subtitle in the Today section showed e.g. "June 26, 2026, 9:41 AM GMT+1". Since the section is inherently about today, the year adds no useful context.

**Before:** June 26, 2026, 9:41 AM GMT+1
**After:** June 26, 9:41 AM GMT+1

One-line change to the format string in `Today.vue`.