### PR TITLE
fix(events): hide duration when child event in progress

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -22,7 +22,7 @@ import {
 } from '../../utils/eventUtils';
 import { PortableText } from 'astro-portabletext';
 import dayjs from '../../lib/dayjs';
-import { getEventEnd } from '../../utils/progressUtils';
+import { getEventEnd, isHappeningNow } from '../../utils/progressUtils';
 
 export const prerender = false;
 
@@ -132,8 +132,20 @@ const enumeratedChildTypes = (() => {
 })();
 
 // Duration display for child events with both start and end dates.
+// Hidden once the event is in progress or has ended, matching the listing
+// (EventChild.vue) where progress/ended state replaces the duration.
 const eventDuration = (() => {
   if (!isChildEvent || !event.dateStart || !event.dateEnd) return null;
+  const progressOptions = {
+    dateStart: event.dateStart,
+    dateEnd: event.dateEnd,
+    timezone: event.timezone,
+    day: event.day,
+    type: event.type,
+  };
+  const now = dayjs();
+  if (isHappeningNow(now, progressOptions)) return null;
+  if (now.isAfter(getEventEnd(progressOptions))) return null;
   const minutes = dayjs(event.dateEnd).diff(dayjs(event.dateStart), 'minutes');
   if (minutes <= 0) return null;
   if (minutes <= 60) {

--- a/src/styles/_events.css
+++ b/src/styles/_events.css
@@ -128,17 +128,6 @@
   flex: 1 1 100%;
 }
 
-/* When a countdown/progress element forces the dates block to span the full
-   row, the duration drops onto its own line. Suppress the leading separator
-   so it reads cleanly ("3 hours long") instead of as a dangling "· 3 hours
-   long" bullet. Matches the direct child of .event__meta that contains the
-   progress element so it works whether or not EventDate is wrapped in an
-   Astro island (client:only) on the detail page. */
-.event__meta > *:has(.event__progress) ~ .event__duration::before {
-  content: none;
-  margin-right: 0;
-}
-
 .event > .event__description {
   order: 4;
 }


### PR DESCRIPTION
Child event detail pages showed the duration on its own line beneath the in-progress/ended indicator. It should be replaced by that indicator, as in the listings.

Gates `eventDuration` in `[slug].astro` on the same `isHappeningNow`/ended state `EventChild.vue` uses, so no duration renders while progress info shows. Drops the obsolete dangling-`·` CSS workaround, now unreachable.

`astro build` and `vitest run` (304) pass.