### PR TITLE
Add GitHub accessibility scanner workflow

### DIFF
--- a/.github/workflows/accessibility-scanner.yml
+++ b/.github/workflows/accessibility-scanner.yml
@@ -1,0 +1,29 @@
+name: Accessibility Scanner
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Every Monday at 10:00 UTC
+    - cron: '0 10 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan production pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: github/accessibility-scanner@v3
+        with:
+          urls: |
+            https://eventua11y.com/
+            https://eventua11y.com/past-events
+            https://eventua11y.com/accessibility
+            https://eventua11y.com/curation-policy
+          repository: ${{ github.repository }}
+          token: ${{ secrets.A11Y_SCANNER_TOKEN }}
+          cache_key: .github/accessibility-scanner/eventua11y.com-main.json
+          open_grouped_issues: true
+          group_by: rule+url

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ This runs Prettier/ESLint checks, builds the Astro site, and uploads source maps
 
 ## CI/CD
 
-Pull requests trigger a GitHub Actions workflow that runs unit tests and end-to-end tests against Netlify deploy previews. An additional workflow checks for missing alt text on images.
+Pull requests trigger a GitHub Actions workflow that runs unit tests and end-to-end tests against Netlify deploy previews. Additional workflows check for missing alt text on images and run the GitHub accessibility scanner against key production pages on a weekly schedule (or manually).
+
+The accessibility scanner workflow requires an `A11Y_SCANNER_TOKEN` repository secret (a fine-grained PAT with `actions: write`, `contents: write`, `issues: write`, `pull-requests: write`, and `metadata: read`).
 
 Dependency updates are managed by [Dependabot](https://docs.github.com/en/code-security/dependabot).
 


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow using `github/accessibility-scanner@v3`
- run scans on key production pages via `workflow_dispatch` and weekly schedule
- document `A11Y_SCANNER_TOKEN` requirements in README
- confirm there were no existing axe/pa11y GitHub Actions workflows to remove

## Notes
- scanner uses grouped issues (`group_by: rule+url`) and a stable cache key