### PR TITLE
feat: report the run context with the accessibility scan

### DIFF
--- a/.github/workflows/accessibility-scanner.yml
+++ b/.github/workflows/accessibility-scanner.yml
@@ -71,7 +71,7 @@ jobs:
           payload=$(jq -n \
             --arg productRef "eventua11ycom" \
             --arg idempotencyKey "${{ github.run_id }}-${{ github.run_attempt }}" \
-            --arg externalUrl "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg externalUrl "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" \
             --arg trigger "${{ github.event_name == 'schedule' && 'schedule' || 'manual' }}" \
             --argjson runNumber ${{ github.run_number }} \
             --argjson runAttempt ${{ github.run_attempt }} \

--- a/.github/workflows/accessibility-scanner.yml
+++ b/.github/workflows/accessibility-scanner.yml
@@ -66,11 +66,17 @@ jobs:
             findings='[]'
           fi
 
+          # No ref or commitSha: this scans whatever is deployed at
+          # eventua11y.com, which may lag the current main.
           payload=$(jq -n \
             --arg productRef "eventua11ycom" \
             --arg idempotencyKey "${{ github.run_id }}-${{ github.run_attempt }}" \
+            --arg externalUrl "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --arg trigger "${{ github.event_name == 'schedule' && 'schedule' || 'manual' }}" \
+            --argjson runNumber ${{ github.run_number }} \
+            --argjson runAttempt ${{ github.run_attempt }} \
             --argjson findings "$findings" \
-            '{productRef: $productRef, type: "automated_scan", tool: "github-accessibility-scanner", idempotencyKey: $idempotencyKey, findings: $findings}')
+            '{productRef: $productRef, type: "automated_scan", tool: "github-accessibility-scanner", idempotencyKey: $idempotencyKey, externalUrl: $externalUrl, context: {trigger: $trigger, environment: "production", runNumber: $runNumber, runAttempt: $runAttempt}, findings: $findings}')
 
           http_code=$(curl -s -o response.txt -w "%{http_code}" -X POST https://api.ablebase.org/ingest/test-activity \
             -H "Authorization: Bearer $ABLEBASE_INGEST_KEY" \


### PR DESCRIPTION
Ablebase can now record where a scan ran, so its Testing list can tell a scan of a live site apart from a scan of a branch preview. This scan reports neither, so its entries show no context and don't link back to the run that produced them.

Adds a `context` object to the ingest payload, plus the `externalUrl` that was already missing:

```json
"externalUrl": "https://github.com/eventua11y/eventua11y.com/actions/runs/30217652962",
"context": {
  "trigger": "schedule",
  "environment": "production",
  "runNumber": 42,
  "runAttempt": 1
}
```

`environment` is `production` because the scanner targets the live URLs. That makes this the first producer reporting evidence that actually describes a deployed product, which is what Ablebase's grade rules need in order to weigh a preview scan differently from a real one.

`trigger` distinguishes the weekly cron from a manual **Run workflow** click, so an ad hoc scan doesn't look like the scheduled one.

Deliberately no `ref` or `commitSha`. Both are available, but they'd name whatever `main` points at when the cron fires, and the deployed site may be older. Recording a commit implies the scan evaluated that code, and nothing here verifies that.

Payload verified by running the `jq` locally with sample values; workflow YAML parses.