### PR TITLE
Add chocks feature tree

### DIFF
--- a/.chocks/apis/get-books-api.chocks.md
+++ b/.chocks/apis/get-books-api.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Get Books API
+status: released
+tags:
+  - sanity
+sort: a0
+uid: c99221c846
+---
+
+Netlify edge function at `/api/get-books` that fetches current and upcoming book club selections from Sanity, cached for 5 minutes.

--- a/.chocks/apis/get-events-api.chocks.md
+++ b/.chocks/apis/get-events-api.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Get Events API
+status: released
+tags:
+  - sanity
+sort: a1
+uid: ea63f52402
+---
+
+Netlify edge function at `/api/get-events` that fetches parent and child events from Sanity, classifies them into today/future/past, and caches the response for 5 minutes with stale-while-revalidate.

--- a/.chocks/apis/get-user-info-api.chocks.md
+++ b/.chocks/apis/get-user-info-api.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Get User Info API
+status: released
+tags:
+  - javascript
+sort: a2
+uid: c77dfcb41e
+---
+
+Netlify edge function at `/api/get-user-info` returning the visitor's user agent, language preference, timezone, and geolocation from request headers and context.

--- a/.chocks/apis/index.chocks.md
+++ b/.chocks/apis/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Data APIs
+status: released
+tags:
+  - sanity
+  - javascript
+sort: a0
+uid: e31561c5f4
+---
+
+Netlify edge functions that serve event, book club, and visitor data to the front end, each cached at the edge.

--- a/.chocks/book-club.chocks.md
+++ b/.chocks/book-club.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Accessibility Book Club Selections
+status: released
+tags:
+  - sanity
+  - javascript
+sort: a1
+uid: a09aaeccbe
+---
+
+Book club entries shown in the event listing, grouped by month, as "Accessibility Book Club is reading [Title]" with a link to the book. Data comes from the `get-books` edge function.

--- a/.chocks/events/event-detail-page.chocks.md
+++ b/.chocks/events/event-detail-page.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Event Detail Page
+status: released
+tags:
+  - sanity
+  - accessibility
+sort: a0
+uid: ff100971ba
+---
+
+Full page for a single event: description, speakers, delivery mode, location, organizer, hashtags with copy-to-clipboard, and JSON-LD structured data for search engines.

--- a/.chocks/events/event-metadata/child-event-listing.chocks.md
+++ b/.chocks/events/event-metadata/child-event-listing.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Child Event Listing
+status: released
+tags:
+  - javascript
+sort: a0
+uid: efaa8424c4
+---
+
+Ordered list of a parent event's child sessions on its detail page, each with its own dates, format, speakers and progress state.

--- a/.chocks/events/event-metadata/delivery-mode-display.chocks.md
+++ b/.chocks/events/event-metadata/delivery-mode-display.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Delivery Mode Display
+status: released
+tags:
+  - javascript
+sort: a1
+uid: ee99453340
+---
+
+Shows whether an event is online, in-person, mixed, or international, with an appropriate icon and location name where relevant.

--- a/.chocks/events/event-metadata/event-badges.chocks.md
+++ b/.chocks/events/event-metadata/event-badges.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Event Information Badges
+status: released
+tags:
+  - javascript
+sort: a2
+uid: e2cab4060f
+---
+
+Badges on event detail pages for "Dedicated to accessibility", "Call for speakers" (with a pulse animation), and "Free" where applicable.

--- a/.chocks/events/event-metadata/event-date-display.chocks.md
+++ b/.chocks/events/event-metadata/event-date-display.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Event Date & Time Display
+status: released
+tags:
+  - dates
+sort: a3
+uid: dedc7135f2
+---
+
+Human-readable start/end dates paired with machine-readable `<time>` elements. Shows a timezone abbreviation for local events and a "Deadline" badge for speaker deadlines.

--- a/.chocks/events/event-metadata/hashtag-display-and-copy.chocks.md
+++ b/.chocks/events/event-metadata/hashtag-display-and-copy.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Event Hashtags with Copy-to-Clipboard
+status: released
+tags:
+  - javascript
+sort: a4
+uid: cb8905c29e
+---
+
+Sidebar section on event detail pages listing the event's hashtags with a copy button for one-click copying.

--- a/.chocks/events/event-metadata/index.chocks.md
+++ b/.chocks/events/event-metadata/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Event Metadata & Display
+status: released
+tags:
+  - javascript
+  - sanity
+sort: a1
+uid: b96034ef0a
+---
+
+The information shown about each event: dates, delivery mode, speakers, hashtags, organizer, supplementary links, and parent/child conference relationships.

--- a/.chocks/events/event-metadata/noscript-fallback.chocks.md
+++ b/.chocks/events/event-metadata/noscript-fallback.chocks.md
@@ -1,0 +1,10 @@
+---
+title: No-JavaScript Fallback Rendering
+status: released
+tags:
+  - accessibility
+sort: a5
+uid: b8285a2cce
+---
+
+Server-rendered event content inside `<noscript>` tags, so listings and event details remain indexable and accessible when JavaScript is disabled.

--- a/.chocks/events/event-metadata/organizer-information.chocks.md
+++ b/.chocks/events/event-metadata/organizer-information.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Organizer Information Display
+status: released
+tags:
+  - sanity
+sort: a6
+uid: ec7e702fae
+---
+
+Shows the event organizer's name and website link in the sidebar when available, marked as an external link.

--- a/.chocks/events/event-metadata/parent-child-hierarchy.chocks.md
+++ b/.chocks/events/event-metadata/parent-child-hierarchy.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Parent/Child Event Hierarchy
+status: released
+tags:
+  - javascript
+sort: a7
+uid: d4ade61a78
+---
+
+Shows the relationship between a multi-part event (e.g. a conference) and its child sessions. The parent's detail page lists all children; each child links back to "Part of [parent]".

--- a/.chocks/events/event-metadata/rich-text-description.chocks.md
+++ b/.chocks/events/event-metadata/rich-text-description.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Rich Text Event Descriptions
+status: released
+tags:
+  - sanity
+sort: a8
+uid: abef6d7d65
+---
+
+Event descriptions authored as Portable Text in Sanity and rendered via astro-portabletext, supporting formatting, links and lists. Falls back to plain text where available.

--- a/.chocks/events/event-metadata/speaker-display.chocks.md
+++ b/.chocks/events/event-metadata/speaker-display.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Speaker Names & Attribution
+status: released
+tags:
+  - javascript
+sort: a9
+uid: f917fa134b
+---
+
+Displays speaker names for events and child sessions, e.g. "Talk by Speaker Name". Deduplicates speakers across a parent event's child sessions.

--- a/.chocks/events/event-metadata/structured-data-json-ld.chocks.md
+++ b/.chocks/events/event-metadata/structured-data-json-ld.chocks.md
@@ -1,0 +1,10 @@
+---
+title: JSON-LD Structured Data
+status: released
+tags:
+  - sanity
+sort: aA
+uid: ddf7253152
+---
+
+Event schema.org JSON-LD markup on detail pages covering metadata, speakers, organizer, attendance mode, location, and subevents for parent events.

--- a/.chocks/events/event-metadata/supplementary-links.chocks.md
+++ b/.chocks/events/event-metadata/supplementary-links.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Supplementary Event Links
+status: released
+tags:
+  - sanity
+sort: aB
+uid: f8755f314e
+---
+
+Sidebar links to registration, code of conduct, accessibility information, schedule, and call for speakers. Hidden automatically once the event has ended.

--- a/.chocks/events/index.chocks.md
+++ b/.chocks/events/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Events
+status: released
+tags:
+  - dates
+  - sanity
+sort: a2
+uid: a3c67d1b33
+---
+
+The core event browsing experience: listing upcoming and past accessibility events, individual event detail pages, and the live "today" view. Content is sourced from Sanity and rendered with server-side fallbacks for accessibility and search indexing.

--- a/.chocks/events/month-navigation.chocks.md
+++ b/.chocks/events/month-navigation.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Month Navigation Sidebar
+status: released
+tags:
+  - javascript
+  - accessibility
+sort: a2
+uid: b898460515
+---
+
+Sidebar for jumping between months in the upcoming listing, or back to today. Highlights the current month via an intersection observer as the user scrolls, and respects prefers-reduced-motion.

--- a/.chocks/events/past-events-listing.chocks.md
+++ b/.chocks/events/past-events-listing.chocks.md
@@ -1,0 +1,12 @@
+---
+title: Past Events Listing
+status: released
+tags:
+  - filtering
+  - dates
+  - sanity
+sort: a3
+uid: f483b6fe61
+---
+
+Separate page listing events from the last 12 months, grouped by month. Excludes speaker deadline entries. Shares filtering and month navigation with the upcoming listing.

--- a/.chocks/events/progress-display/countdown-timer.chocks.md
+++ b/.chocks/events/progress-display/countdown-timer.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Countdown to Event Start
+status: released
+tags:
+  - dates
+sort: a0
+uid: c5c1501695
+---
+
+In the Today section, shows the time remaining until an event starts. Only appears for events that haven't started yet today.

--- a/.chocks/events/progress-display/event-duration-display.chocks.md
+++ b/.chocks/events/progress-display/event-duration-display.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Event Duration Label
+status: released
+tags:
+  - dates
+sort: a1
+uid: d48a377207
+---
+
+Shows a duration label (e.g. "45 minutes long") for child events with an explicit end time. Hidden while the event is in progress or after it has ended.

--- a/.chocks/events/progress-display/event-ended-state.chocks.md
+++ b/.chocks/events/progress-display/event-ended-state.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Event Ended Status Display
+status: released
+tags:
+  - dates
+sort: a2
+uid: b13a941afc
+---
+
+Shows when an event ended and how long ago (e.g. "Ended 2 hours ago") in the Today section and on detail pages. Hidden on other listing pages once the event has ended.

--- a/.chocks/events/progress-display/index.chocks.md
+++ b/.chocks/events/progress-display/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Event Progress Indicators
+status: released
+tags:
+  - dates
+  - javascript
+sort: a4
+uid: cf4a07fd38
+---
+
+Live indicators of where an event is in its lifecycle: countdown to start, in-progress bar, duration, and ended state.

--- a/.chocks/events/progress-display/live-progress-bar.chocks.md
+++ b/.chocks/events/progress-display/live-progress-bar.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Live Progress Bar During Event
+status: released
+tags:
+  - dates
+  - javascript
+sort: a3
+uid: e0d84d5931
+---
+
+Animated bar showing progress through an in-progress child event, with a time-remaining label. Updates every 15 seconds.

--- a/.chocks/events/today-section.chocks.md
+++ b/.chocks/events/today-section.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Today Section
+status: released
+tags:
+  - dates
+  - javascript
+sort: a5
+uid: e5a6bd4d5b
+---
+
+Live-updating section at the top of the upcoming listing showing events happening today, with the current time and theme/awareness day events reordered to appear first. Refreshes every minute.

--- a/.chocks/events/upcoming-events-listing.chocks.md
+++ b/.chocks/events/upcoming-events-listing.chocks.md
@@ -1,0 +1,12 @@
+---
+title: Upcoming Events Listing
+status: released
+tags:
+  - filtering
+  - dates
+  - sanity
+sort: a6
+uid: f161c606c0
+---
+
+Main page showing upcoming accessibility events grouped by month. Server-rendered with Vue islands for client-side filtering. Data comes from Sanity via an edge function cached for 5 minutes.

--- a/.chocks/filtering/filter-by-attendance-mode.chocks.md
+++ b/.chocks/filtering/filter-by-attendance-mode.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Filter by Attendance Mode
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a0
+uid: da5c2c7891
+---
+
+Radio group to filter events by online, in-person, or mixed attendance. Defaults to no preference. Selection persists to localStorage.

--- a/.chocks/filtering/filter-by-call-for-speakers.chocks.md
+++ b/.chocks/filtering/filter-by-call-for-speakers.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Filter by Call for Speakers Status
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a1
+uid: c5a896f22c
+---
+
+Radio group to show events currently accepting talks, not accepting talks, or both, evaluated against each event's call-for-speakers closing date.

--- a/.chocks/filtering/filter-by-cost.chocks.md
+++ b/.chocks/filtering/filter-by-cost.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Filter by Ticket Cost
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a2
+uid: d225b487dc
+---
+
+Radio group to show only free events, only paid events, or both. Selection persists to localStorage.

--- a/.chocks/filtering/filter-persistence.chocks.md
+++ b/.chocks/filtering/filter-persistence.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Filter State Persistence
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a3
+uid: f92386125d
+---
+
+All filter selections are saved to localStorage and restored automatically on page reload or browser restart.

--- a/.chocks/filtering/filter-result-count.chocks.md
+++ b/.chocks/filtering/filter-result-count.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Filter Result Count
+status: released
+tags:
+  - filtering
+  - accessibility
+sort: a4
+uid: ab8fee40e8
+---
+
+Live region reporting how many events match the current filters, updating as filters change and announced to screen readers.

--- a/.chocks/filtering/index.chocks.md
+++ b/.chocks/filtering/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Event Filtering
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a3
+uid: a644b500d6
+---
+
+Controls for narrowing the event list by attendance mode, cost, call-for-speakers status, and content type. Selections persist to localStorage and are reflected in a live result count.

--- a/.chocks/filtering/reset-filters.chocks.md
+++ b/.chocks/filtering/reset-filters.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Reset Filters
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a5
+uid: a1a7d9f942
+---
+
+Button, in both the filter bar and drawer, that resets all filters to their defaults and clears the persisted state. Only visible when a filter differs from default.

--- a/.chocks/filtering/toggle-awareness-days.chocks.md
+++ b/.chocks/filtering/toggle-awareness-days.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Toggle Awareness Days
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a6
+uid: ccfae1b2b8
+---
+
+Switch, present in both the filter drawer and the sticky filter bar, to show or hide awareness days and theme events. Defaults to on.

--- a/.chocks/filtering/toggle-book-club.chocks.md
+++ b/.chocks/filtering/toggle-book-club.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Toggle Book Club Selections
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a7
+uid: d2504a0119
+---
+
+Switch to show or hide accessibility book club selections in the event listing. Defaults to on.

--- a/.chocks/filtering/toggle-speaker-deadlines.chocks.md
+++ b/.chocks/filtering/toggle-speaker-deadlines.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Toggle Speaker Deadlines
+status: released
+tags:
+  - filtering
+  - javascript
+sort: a8
+uid: c2d81ad678
+---
+
+Switch to include or exclude speaker deadline entries from filtered results. Defaults to on.

--- a/.chocks/navigation-and-layout/filter-drawer.chocks.md
+++ b/.chocks/navigation-and-layout/filter-drawer.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Filter Drawer
+status: released
+tags:
+  - javascript
+  - accessibility
+sort: a0
+uid: c283df1563
+---
+
+Slide-out drawer holding all filter controls, opened from a header button, including the reset button and event count.

--- a/.chocks/navigation-and-layout/index.chocks.md
+++ b/.chocks/navigation-and-layout/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Navigation & Layout
+status: released
+tags:
+  - javascript
+  - accessibility
+sort: a4
+uid: b8546094e4
+---
+
+Site-wide structure: primary navigation, the sticky filter bar, the filter drawer, and responsive layout behaviour across breakpoints.

--- a/.chocks/navigation-and-layout/primary-navigation.chocks.md
+++ b/.chocks/navigation-and-layout/primary-navigation.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Primary Navigation Menu
+status: released
+tags:
+  - accessibility
+sort: a1
+uid: cd012780c2
+---
+
+Header navigation linking to Upcoming, Past Events, and Topics (when the topics flag is on), with `aria-current="page"` marking the active link.

--- a/.chocks/navigation-and-layout/responsive-layout.chocks.md
+++ b/.chocks/navigation-and-layout/responsive-layout.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Responsive Layout
+status: released
+tags:
+  - accessibility
+  - javascript
+sort: a2
+uid: d5da04f958
+---
+
+Adaptive layout with breakpoints at 700px and 769px: the filter button switches between icon-only and icon-plus-label, and the event detail sidebar moves below the main content on small screens.

--- a/.chocks/navigation-and-layout/sticky-filter-bar.chocks.md
+++ b/.chocks/navigation-and-layout/sticky-filter-bar.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Sticky Filter Bar
+status: released
+tags:
+  - javascript
+sort: a3
+uid: ec7b53334d
+---
+
+Filter bar with the awareness days toggle, filter button, and timezone selector, which sticks to the viewport on scroll via an intersection observer and shows the current result count.

--- a/.chocks/pages/404-error-page.chocks.md
+++ b/.chocks/pages/404-error-page.chocks.md
@@ -1,0 +1,10 @@
+---
+title: 404 Error Page
+status: released
+tags:
+  - accessibility
+sort: a0
+uid: bba2e21968
+---
+
+Custom prerendered 404 page using a stripped-down layout without primary navigation, so it can stay prerendered while flag-gated nav content cannot.

--- a/.chocks/pages/accessibility-statement-page.chocks.md
+++ b/.chocks/pages/accessibility-statement-page.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Accessibility Statement Page
+status: released
+tags:
+  - accessibility
+sort: a1
+uid: fd19aa6f94
+---
+
+Public page at `/accessibility` covering the site's accessibility standards (WCAG 2.2 AA), testing methods, known issues, and a contact email for reporting problems.

--- a/.chocks/pages/curation-policy-page.chocks.md
+++ b/.chocks/pages/curation-policy-page.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Curation Policy Page
+status: released
+tags:
+  - content
+sort: a2
+uid: bc0323931c
+---
+
+Public page at `/curation-policy` explaining event selection criteria: subject matter, English-language requirement, accessibility policy requirements, and overlay product restrictions.

--- a/.chocks/pages/index.chocks.md
+++ b/.chocks/pages/index.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Static Pages
+status: released
+tags:
+  - content
+sort: a5
+uid: c24042ac79
+---
+
+Standalone informational pages outside the event listing: accessibility statement, curation policy, sitemap, and the 404 page.

--- a/.chocks/pages/sitemap.chocks.md
+++ b/.chocks/pages/sitemap.chocks.md
@@ -1,0 +1,10 @@
+---
+title: XML Sitemap
+status: released
+tags:
+  - seo
+sort: a3
+uid: eb9f2c956c
+---
+
+Dynamically generated `sitemap.xml` for search engine crawling and discoverability.

--- a/.chocks/preferences/index.chocks.md
+++ b/.chocks/preferences/index.chocks.md
@@ -1,0 +1,10 @@
+---
+title: User Preferences
+status: released
+tags:
+  - javascript
+sort: a6
+uid: d9d95350a1
+---
+
+Visitor-level settings stored in localStorage: colour theme and detected geolocation/timezone data.

--- a/.chocks/preferences/theme-selection.chocks.md
+++ b/.chocks/preferences/theme-selection.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Light/Dark/System Theme Selection
+status: released
+tags:
+  - javascript
+  - accessibility
+sort: a0
+uid: bd7a192580
+---
+
+Header dropdown for light, dark, or system-default colour theme. Persists to localStorage and respects `prefers-color-scheme` when set to system.

--- a/.chocks/preferences/user-geo-data-storage.chocks.md
+++ b/.chocks/preferences/user-geo-data-storage.chocks.md
@@ -1,0 +1,10 @@
+---
+title: User Geolocation & Timezone Storage
+status: released
+tags:
+  - javascript
+sort: a1
+uid: bfa313b1a3
+---
+
+Stores the visitor's timezone, locale, and geolocation (country, region, city) in localStorage, fetched once per session from the `get-user-info` edge function.

--- a/.chocks/timezone-and-locale/index.chocks.md
+++ b/.chocks/timezone-and-locale/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Timezone & Locale
+status: released
+tags:
+  - dates
+  - javascript
+sort: a7
+uid: c9a5a02e5b
+---
+
+Detecting the visitor's timezone and locale, converting event times accordingly, and letting them switch between their local time and the event's own timezone.

--- a/.chocks/timezone-and-locale/locale-support.chocks.md
+++ b/.chocks/timezone-and-locale/locale-support.chocks.md
@@ -1,0 +1,10 @@
+---
+title: Locale Support
+status: released
+tags:
+  - dates
+sort: a0
+uid: e9b044934a
+---
+
+Date formatting in English, Spanish, French, and German, following the visitor's browser language preference.

--- a/.chocks/timezone-and-locale/timezone-conversion.chocks.md
+++ b/.chocks/timezone-and-locale/timezone-conversion.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Event Date Timezone Conversion
+status: released
+tags:
+  - dates
+  - javascript
+sort: a1
+uid: b1af3ac2de
+---
+
+Converts event times from the event's own timezone to the visitor's selected timezone, handling international events, single-day events, and multi-day events.

--- a/.chocks/timezone-and-locale/timezone-detection.chocks.md
+++ b/.chocks/timezone-and-locale/timezone-detection.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Automatic User Timezone Detection
+status: released
+tags:
+  - dates
+  - javascript
+sort: a2
+uid: a01ef057ce
+---
+
+Detects the visitor's timezone from Netlify geolocation headers via the `get-user-info` edge function, falling back to UTC if detection fails.

--- a/.chocks/timezone-and-locale/timezone-selector.chocks.md
+++ b/.chocks/timezone-and-locale/timezone-selector.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Timezone Selector Dropdown
+status: released
+tags:
+  - dates
+  - javascript
+sort: a3
+uid: bca23be870
+---
+
+Dropdown to switch between the visitor's local timezone (with UTC offset) and the event's own local time. Selection persists to localStorage.

--- a/.chocks/topics/event-topic-links.chocks.md
+++ b/.chocks/topics/event-topic-links.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Event-to-Topic Links
+status: pre-release
+tags:
+  - sanity
+  - javascript
+sort: a0
+uid: a339a225aa
+---
+
+Related-topics links on event detail pages pointing to topic pages, and inclusion of topics in the event's JSON-LD "about" field. Only shown when the flag is enabled.

--- a/.chocks/topics/index.chocks.md
+++ b/.chocks/topics/index.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Topics
+status: pre-release
+tags:
+  - sanity
+  - javascript
+sort: a8
+uid: f63d9ede25
+---
+
+Browsing events by topic. Gated behind the `topic_pages_enabled` feature flag; the index and detail pages 404 when the flag is off.

--- a/.chocks/topics/topic-detail-page.chocks.md
+++ b/.chocks/topics/topic-detail-page.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Topic Detail Page
+status: pre-release
+tags:
+  - sanity
+  - javascript
+sort: a1
+uid: af3160383f
+---
+
+Page for a single topic with a rich text body and a list of related upcoming events. Gated behind the `topic_pages_enabled` flag.

--- a/.chocks/topics/topic-index-page.chocks.md
+++ b/.chocks/topics/topic-index-page.chocks.md
@@ -1,0 +1,11 @@
+---
+title: Topic Index
+status: pre-release
+tags:
+  - sanity
+  - javascript
+sort: a2
+uid: d551aee046
+---
+
+Alphabetically-grouped directory of all published topics, showing each topic's description and its count of upcoming events. Gated behind the `topic_pages_enabled` flag.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Instructions for AI agents and subagents working in this repository.
 
+## Product context
+
+At the start of a session, run `npx chocks context` and use its feature tree as context for the product's scope, status and terminology. The tree lives in `.chocks/` as a directory of markdown files: one per feature, each with a `status` of `planned`, `pre-release`, `released`, `deprecated`, or `dropped`. Edit these files directly (or run `npx chocks` for a UI) when a change ships or a feature's status moves.
+
 ## Agent Team
 
 Agent instruction files live in `.agents/` (platform-agnostic). Platform-specific configs live in `.opencode/agents/` and reference the `.agents/` files. Skills are in `.agents/skills/` (installed from [mattobee/skills](https://github.com/mattobee/skills)) and `.opencode/skills/` (project-specific).

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@eslint/js": "^10.0.1",
+        "@mattobee/chocks": "^0.6.0",
         "@playwright/test": "^1.60.0",
         "@portabletext/types": "^4.0.2",
         "@types/node": "^26.0.1",
@@ -3724,6 +3725,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mattobee/chocks": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mattobee/chocks/-/chocks-0.6.0.tgz",
+      "integrity": "sha512-hty2JFQS0zNBOyFkihbTbt/hLZy4D0caqu5mRVcqLrnadqvZpe7+iVfi6Ya6dAVGznkTW2wlErMKv8fyjj2heg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "chocks": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.19"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "format": "prettier --write .",
     "lint": "eslint . --fix",
     "knip": "knip",
-    "check:freshness": "node scripts/check-event-freshness.mjs --dry-run"
+    "check:freshness": "node scripts/check-event-freshness.mjs --dry-run",
+    "chocks": "chocks"
   },
   "repository": {
     "type": "git",
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^10.0.1",
+    "@mattobee/chocks": "^0.6.0",
     "@playwright/test": "^1.60.0",
     "@portabletext/types": "^4.0.2",
     "@types/node": "^26.0.1",


### PR DESCRIPTION
Adds [chocks](https://github.com/mattobee/chocks), a dev tool that tracks the product's features as a tree of markdown files in the repo instead of an issue tracker. `.chocks/` now has a starter tree covering the site's current capabilities (event browsing, filtering, timezone/locale, topics, book club, preferences, and the edge function APIs), read from the codebase and marked with an accurate status for each.

AGENTS.md points coding agents at `npx chocks context` so they pick up product scope and terminology from the tree rather than inferring it from code.

The tree is a starting point, not a finished one: statuses and descriptions should be reviewed and corrected where they don't match what's actually in your head.