### PR TITLE
Document chocks feature tree in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,13 @@ See the [contributing guide](CONTRIBUTING.md) for ways to get involved in this p
 
 ## Feature tree
 
-This project records what the product does and the state of each part in [`.chocks/`](.chocks), a tree of markdown files managed by [Chocks](https://github.com/mattobee/chocks). Each feature has a status (`planned`, `pre-release`, `released`, `deprecated`, or `dropped`), tags, and a short description. GitHub Issues is still used to track work.
+This project records what the product does and the state of each part in [`.chocks/`](.chocks), a tree of markdown files managed by [Chocks](https://github.com/mattobee/chocks).
 
 Browse or edit the tree with the Chocks UI:
 
 ```sh
 npm run chocks
 ```
-
-This runs on port 5959, since Chocks' default port (4321) is the fixed port the Astro dev server uses (see [Fixed Development Ports](AGENTS.md#fixed-development-ports) in AGENTS.md).
 
 Coding agents should run `npx chocks context` at the start of a session to load the tree as product context; see [AGENTS.md](AGENTS.md).
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ The goal is for each page of this website to meet the requirements of [WCAG 2.2]
 
 See the [contributing guide](CONTRIBUTING.md) for ways to get involved in this project, including some that don't require you to write a single line of code.
 
+## Feature tree
+
+This project records what the product does and the state of each part in [`.chocks/`](.chocks), a tree of markdown files managed by [Chocks](https://github.com/mattobee/chocks). Each feature has a status (`planned`, `pre-release`, `released`, `deprecated`, or `dropped`), tags, and a short description. GitHub Issues is still used to track work.
+
+Browse or edit the tree with the Chocks UI:
+
+```sh
+npm run chocks
+```
+
+This runs on port 5959, since Chocks' default port (4321) is the fixed port the Astro dev server uses (see [Fixed Development Ports](AGENTS.md#fixed-development-ports) in AGENTS.md).
+
+Coding agents should run `npx chocks context` at the start of a session to load the tree as product context; see [AGENTS.md](AGENTS.md).
+
 ## Technology
 
 ### Frameworks and languages

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint . --fix",
     "knip": "knip",
     "check:freshness": "node scripts/check-event-freshness.mjs --dry-run",
-    "chocks": "chocks"
+    "chocks": "chocks -p 5959"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
PR #845 merged the chocks feature tree itself but not the README documentation for it (those commits were pushed after the merge). This adds the missing README section and fixes the `chocks` npm script to bind to port 5959 instead of its default 4321, which clashes with the Astro dev server's fixed port.